### PR TITLE
use bash from PATH

### DIFF
--- a/packages/bosh-alicloud-cpi/packaging
+++ b/packages/bosh-alicloud-cpi/packaging
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables


### PR DESCRIPTION
If bash is not located in /usr/bin/bash the alicloud cpi fails. This change is to use the bash provided within the path.
