### PR TITLE
Return NotSupported on shrink so director falls back to copy migration

### DIFF
--- a/src/bosh-alicloud-cpi/action/update_disk.go
+++ b/src/bosh-alicloud-cpi/action/update_disk.go
@@ -48,7 +48,10 @@ func (a UpdateDiskMethod) UpdateDisk(diskCID apiv1.DiskCID, newSize int, cloudPr
 
 	newSizeGB := ConvertToGB(float64(newSize))
 	if newSizeGB < disk.Size {
-		return diskCID, bosherr.Errorf("UpdateDisk cannot shrink disk %s: requested %d GB < current %d GB",
+		// AliCloud can't shrink in-place. Return NotSupported (not a generic error) so
+		// the director falls back to its copy/migrate path, as it did before update_disk.
+		return diskCID, alicloud.NewNotSupportedError(
+			"UpdateDisk cannot shrink disk %s in-place: requested %d GB < current %d GB",
 			diskCid, newSizeGB, disk.Size)
 	}
 

--- a/src/bosh-alicloud-cpi/action/update_disk_test.go
+++ b/src/bosh-alicloud-cpi/action/update_disk_test.go
@@ -140,7 +140,10 @@ var _ = Describe("cpi:update_disk", func() {
 	})
 
 	Context("failure modes", func() {
-		It("rejects shrink requests with a plain error, NOT Bosh::Clouds::NotSupported", func() {
+		It("returns Bosh::Clouds::NotSupported for a shrink so the director falls back to copy migration", func() {
+			// AliCloud can't shrink in-place. The CPI returns NotSupported (not a
+			// generic error) so the director's copy/migrate path handles the shrink,
+			// matching the behavior from before update_disk existed.
 			cid, disk := mockContext.NewDisk("")
 			disk.Category = string(alicloud.DiskCategoryCloudESSD)
 			initialSize := disk.Size
@@ -149,7 +152,7 @@ var _ = Describe("cpi:update_disk", func() {
 				"category": string(alicloud.DiskCategoryCloudESSD),
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).NotTo(ContainSubstring(`"type":"Bosh::Clouds::NotSupported"`))
+			Expect(err.Error()).To(ContainSubstring(`"type":"Bosh::Clouds::NotSupported"`))
 			Expect(err.Error()).To(ContainSubstring("cannot shrink"))
 
 			updated := mockContext.Disks[cid]


### PR DESCRIPTION
UpdateDisk rejected a shrink with a generic Bosh::Clouds::CloudError, which the director does not catch — so a deployment that reduces a persistent disk (live disk is larger than the configured disk_type) failed the deploy outright.

Before update_disk existed, such a shrink fell through to the director's copy/migrate path (create smaller disk, agent-rsync data, orphan the old disk), which handles shrinks fine. The director only triggers that fallback on Bosh::Clouds::NotSupported / NotImplemented. Returning NotSupported for a shrink restores that behavior instead of failing the deploy.

In-place category/PL changes still fail fast; only the shrink guard changes.