### PR TITLE
Read stemcell encryption off the snapshot, which reports it

### DIFF
--- a/ci/tasks/run-nvme-customer-journey.sh
+++ b/ci/tasks/run-nvme-customer-journey.sh
@@ -154,8 +154,24 @@ assert_stemcell_is_nvme_capable() {
   # The director always asks the CPI for an encrypted copy. The source light
   # image already carries NvmeSupport, so without this check a CPI that skips
   # the encrypted CopyImage would still pass the NvmeSupport assertion.
-  expect "image Encrypted" true \
-    "$(echo "${describe_json}" | jq -r '.Images.Image[0].Encrypted // "<absent>"')"
+  #
+  # Encryption is read off the image's system snapshot, not off the image:
+  # DescribeImages reports Encrypted only per DiskDeviceMapping and documents
+  # that field as an invitational preview, while a snapshot's own Encrypted is
+  # long-standing API.
+  local snapshot_id snapshot_json
+  snapshot_id=$(echo "${describe_json}" |
+    jq -er '[ .Images.Image[0].DiskDeviceMappings.DiskDeviceMapping[]
+              | select(.Type == "system") | .SnapshotId ]
+            | first // error("image has no system disk snapshot")')
+  snapshot_json=$(aliyun ecs DescribeSnapshots --region "${region}" \
+    --SnapshotIds "[\"${snapshot_id}\"]")
+  # tostring with no `//`: jq's alternative operator takes the right-hand side
+  # for false as well as for null, so any default here would report an
+  # unencrypted snapshot as though the API had stopped returning the field.
+  # tostring alone still renders a missing field as "null".
+  expect "snapshot ${snapshot_id} Encrypted" true \
+    "$(echo "${snapshot_json}" | jq -r '.Snapshots.Snapshot[0].Encrypted | tostring')"
 }
 assert_stemcell_is_nvme_capable
 
@@ -252,8 +268,10 @@ assert_iaas_state() {
     "$(echo "${disk_json}" | jq -r '.Disks.Disk[0].Category // "<absent>"')"
   # The director encrypts, so a disk that came back unencrypted means the CPI
   # dropped the setting rather than that the test asked for the wrong thing.
+  # tostring for the same reason as the snapshot check above: any `//` default
+  # would report an unencrypted disk as a missing field.
   expect "disk_encrypted" true \
-    "$(echo "${disk_json}" | jq -r '.Disks.Disk[0].Encrypted // "<absent>"')"
+    "$(echo "${disk_json}" | jq -r '.Disks.Disk[0].Encrypted | tostring')"
 
   if [[ -n "${expected_performance_level}" ]]; then
     expect "performance_level" "${expected_performance_level}" \


### PR DESCRIPTION
The journey asserted `.Images.Image[0].Encrypted`, a field `DescribeImages` does
not return. It reports encryption only per `DiskDeviceMapping`, and [documents
even that as an invitational preview][doc]. The assertion could therefore never
pass. It went in with #221 after the last full journey run on the branch, and the
two branch runs that followed died in `put-environment` on `QuotaExceeded.Vpc`
and `KeyPair.AlreadyExist` about a minute in, roughly fifty minutes before the
journey would have executed it, so master's `end-2-end` was the first run to
reach it.

The stemcell it failed on was in fact encrypted correctly: the snapshot behind
that image came back `Encrypted=true` with a KMS key. A snapshot's own
`Encrypted` has been stable API for years, so the check now resolves the image's
system `DiskDeviceMapping` to a snapshot and asks `DescribeSnapshots`.

Both encryption checks also drop `// "<absent>"`. jq's alternative operator takes
the right-hand side for `false` as well as for `null`, so an unencrypted result
was reported as though the API had stopped returning the field -- the same defect
would have hidden a genuinely unencrypted disk behind a message about a missing
field. `tostring` alone still renders a missing field as `"null"`.

Verified against real API responses rather than by inspection, which is what the
original assertion lacked:

| case | result |
| --- | --- |
| encrypted image (rebuilt from the journey's own CopyImage snapshot) | `ok snapshot s-... Encrypted=true` |
| unencrypted image | `FAIL ... expected 'true', got 'false'` |
| empty record / absent field / absent key | `null`, distinct from `false` |

The first attempt at this fix wrote `(.Encrypted // null) | tostring`, which
repeats the very bug it replaces; only running it against a real unencrypted
snapshot surfaced that.

[doc]: https://www.alibabacloud.com/help/en/ecs/developer-reference/api-ecs-2014-05-26-describeimages
