### PR TITLE
Read image encryption from DescribeImages, which the observer role can call

### DIFF
--- a/ci/tasks/run-nvme-customer-journey.sh
+++ b/ci/tasks/run-nvme-customer-journey.sh
@@ -155,23 +155,18 @@ assert_stemcell_is_nvme_capable() {
   # image already carries NvmeSupport, so without this check a CPI that skips
   # the encrypted CopyImage would still pass the NvmeSupport assertion.
   #
-  # Encryption is read off the image's system snapshot, not off the image:
-  # DescribeImages reports Encrypted only per DiskDeviceMapping and documents
-  # that field as an invitational preview, while a snapshot's own Encrypted is
-  # long-standing API.
-  local snapshot_id snapshot_json
-  snapshot_id=$(echo "${describe_json}" |
-    jq -er '[ .Images.Image[0].DiskDeviceMappings.DiskDeviceMapping[]
-              | select(.Type == "system") | .SnapshotId ]
-            | first // error("image has no system disk snapshot")')
-  snapshot_json=$(aliyun ecs DescribeSnapshots --region "${region}" \
-    --SnapshotIds "[\"${snapshot_id}\"]")
-  # tostring with no `//`: jq's alternative operator takes the right-hand side
-  # for false as well as for null, so any default here would report an
-  # unencrypted snapshot as though the API had stopped returning the field.
-  # tostring alone still renders a missing field as "null".
-  expect "snapshot ${snapshot_id} Encrypted" true \
-    "$(echo "${snapshot_json}" | jq -r '.Snapshots.Snapshot[0].Encrypted | tostring')"
+  # DescribeImages reports encryption per disk mapping rather than on the image
+  # itself, so the system disk's mapping is what has to be read. tostring with
+  # no `//`: jq's alternative operator takes the right-hand side for false as
+  # well as for null, so any default here would report an unencrypted image as
+  # though the API had stopped returning the field. tostring alone still renders
+  # a missing mapping as "null", and the `[]?` keeps an empty image list from
+  # failing as a jq error instead of as this assertion.
+  expect "image encrypted" true \
+    "$(echo "${describe_json}" | jq -r '
+      [ .Images.Image[0].DiskDeviceMappings.DiskDeviceMapping[]?
+        | select(.Type == "system") | .Encrypted ]
+      | first | tostring')"
 }
 assert_stemcell_is_nvme_capable
 


### PR DESCRIPTION
`end-2-end` #70 failed on the encryption assertion #222 introduced, immediately after the NvmeSupport check passed:

```
  ok image NvmeSupport=supported
ERROR: SDK.ServerError
ErrorCode: Forbidden.RAM
AccessDeniedDetail: AuthAction: ecs:DescribeSnapshots
                    AuthPrincipalDisplayName: BoshE2EObserverRole:nvme-journey-local-task-0
```

#222 moved the check onto `DescribeSnapshots` to avoid a field the API reference marks as an invitational preview. That was the wrong trade: it swapped a documented field on an authorised API for a stable field on an unauthorised one. `BoshE2EObserverPolicy` grants only the calls the journey already made, and the role is not managed in this repository, so widening it is the larger change of the two. The preview concern was also speculation, while the authorisation failure was not.

The check stays on `DescribeImages` and reads the system disk mapping, which does report `Encrypted`. Only the jq path needed fixing; no new API call, no policy change.

Verified against real responses, including a genuinely encrypted image reconstructed with `CreateImage --SnapshotId` from an encrypted snapshot the journey itself produced:

| case | result |
| --- | --- |
| encrypted image | `ok image encrypted=true` |
| unencrypted image | `FAIL image encrypted: expected 'true', got 'false'` |
| data-only mapping / empty image list / absent field | `null`, and no jq error under `set -e` |

The `[]?` matters for the last row: without it an empty image list aborts the script with `Cannot iterate over null` instead of reporting the assertion.

`integration` is failing separately on `OperationDenied.NoStock` for the spot instance in `eu-central-1a`, which is capacity, not code, and is not addressed here.
