### PR TITLE
Use a longer timeout for the ModifyDiskSpec wait in update_disk

### DIFF
--- a/src/bosh-alicloud-cpi/action/create_stemcell.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell.go
@@ -44,10 +44,10 @@ type StemcellProps struct {
 	//RootDeviceName string 	`json:"root_device_name"`
 	SourceUrl string `json:"source_url"`
 	//SourceSha1    string `json:"raw_disk_sha1,omitempty"`
-	OSSBucket   string                 `json:"oss_bucket"`
-	OSSObject   string                 `json:"oss_object"`
-	Description string                 `json:"description,omitempty"`
-	Version     interface{}            `json:"version"`
+	OSSBucket   string      `json:"oss_bucket"`
+	OSSObject   string      `json:"oss_object"`
+	Description string      `json:"description,omitempty"`
+	Version     interface{} `json:"version"`
 	version     string
 	Images      map[string]interface{} `json:"image_id"`
 }

--- a/src/bosh-alicloud-cpi/action/disks.go
+++ b/src/bosh-alicloud-cpi/action/disks.go
@@ -142,6 +142,21 @@ func (a DiskInfo) Validate(isSystem bool) (DiskInfo, error) {
 		a.path = "/dev/xvdb"
 	}
 	a.ecsCategory = c
+
+	// performance_level applies only to ESSD (PL0-PL3); "" lets ECS choose.
+	// Reject bad input here so it fails fast instead of stalling a ModifyDiskSpec
+	// wait for a PL that ECS silently ignores (e.g. on cloud_auto).
+	if pl := strings.TrimSpace(a.PerformanceLevel); pl != "" {
+		switch pl {
+		case "PL0", "PL1", "PL2", "PL3":
+			if c != alicloud.DiskCategoryCloudESSD {
+				return a, fmt.Errorf("performance_level %s is only supported on cloud_essd, not %s", pl, c)
+			}
+		default:
+			return a, fmt.Errorf("invalid performance_level %q (expected PL0/PL1/PL2/PL3 or empty)", pl)
+		}
+	}
+
 	a.path = alicloud.AmendDiskPath(a.path, a.ecsCategory)
 
 	//

--- a/src/bosh-alicloud-cpi/action/update_disk.go
+++ b/src/bosh-alicloud-cpi/action/update_disk.go
@@ -5,9 +5,18 @@ package action
 
 import (
 	"bosh-alicloud-cpi/alicloud"
+	"time"
 
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+)
+
+// ModifyDiskSpec is asynchronous and can run for many minutes on large disks —
+// longer than the generic WaitForDiskStatus timeout (600s). Give the spec-change
+// wait its own budget, matching the 30 min the Ruby bootstrap-bosh migration uses.
+const (
+	modifyDiskSpecWaitTimeout  = 30 * time.Minute
+	modifyDiskSpecWaitInterval = 10 * time.Second
 )
 
 type UpdateDiskMethod struct {
@@ -71,8 +80,11 @@ func (a UpdateDiskMethod) UpdateDisk(diskCID apiv1.DiskCID, newSize int, cloudPr
 				diskCid, currentCategory, targetCategory, currentPL, targetPL)
 		}
 
-		// Wait for Available before resizing.
-		if _, err := a.disks.WaitForDiskStatus(diskCid, alicloud.DiskStatusAvailable); err != nil {
+		// Wait for the spec change to finish before resizing. The disk passes
+		// through "Modifying" during the conversion; use the long ModifyDiskSpec
+		// timeout (not the generic WaitTimeout) so large-disk conversions don't
+		// time out mid-flight and leave the director to detach a Modifying disk.
+		if _, err := a.disks.WaitForDiskStatus(diskCid, alicloud.DiskStatusAvailable, modifyDiskSpecWaitTimeout, modifyDiskSpecWaitInterval); err != nil {
 			return diskCID, bosherr.WrapErrorf(err, "UpdateDisk WaitForDiskStatus failed for disk %s after spec change", diskCid)
 		}
 	}

--- a/src/bosh-alicloud-cpi/action/update_disk.go
+++ b/src/bosh-alicloud-cpi/action/update_disk.go
@@ -80,10 +80,8 @@ func (a UpdateDiskMethod) UpdateDisk(diskCID apiv1.DiskCID, newSize int, cloudPr
 				diskCid, currentCategory, targetCategory, currentPL, targetPL)
 		}
 
-		// Wait for the spec change to finish before resizing. The disk passes
-		// through "Modifying" during the conversion; use the long ModifyDiskSpec
-		// timeout (not the generic WaitTimeout) so large-disk conversions don't
-		// time out mid-flight and leave the director to detach a Modifying disk.
+		// Wait for the spec change to finish before resizing, using the long
+		// ModifyDiskSpec timeout so large-disk conversions don't time out.
 		if _, err := a.disks.WaitForDiskStatus(diskCid, alicloud.DiskStatusAvailable, modifyDiskSpecWaitTimeout, modifyDiskSpecWaitInterval); err != nil {
 			return diskCID, bosherr.WrapErrorf(err, "UpdateDisk WaitForDiskStatus failed for disk %s after spec change", diskCid)
 		}

--- a/src/bosh-alicloud-cpi/action/update_disk.go
+++ b/src/bosh-alicloud-cpi/action/update_disk.go
@@ -40,6 +40,22 @@ func (a UpdateDiskMethod) UpdateDisk(diskCID apiv1.DiskCID, newSize int, cloudPr
 		return diskCID, bosherr.Errorf("UpdateDisk disk not found id=%s", diskCid)
 	}
 
+	// On retry after a prior timeout the disk may still be Modifying. Wait for it
+	// to settle to Available before reading category/PL, so we don't re-issue
+	// ModifyDiskSpec on a disk that is mid-conversion.
+	if alicloud.DiskStatus(disk.Status) != alicloud.DiskStatusAvailable {
+		if _, err := a.disks.WaitForDiskStatus(diskCid, alicloud.DiskStatusAvailable, modifyDiskSpecWaitTimeout, modifyDiskSpecWaitInterval); err != nil {
+			return diskCID, bosherr.WrapErrorf(err, "UpdateDisk disk %s not Available on entry", diskCid)
+		}
+		disk, err = a.disks.GetDisk(diskCid)
+		if err != nil {
+			return diskCID, bosherr.WrapErrorf(err, "UpdateDisk GetDisk after wait failed %s", diskCid)
+		}
+		if disk == nil {
+			return diskCID, bosherr.Errorf("UpdateDisk disk not found after wait id=%s", diskCid)
+		}
+	}
+
 	var props DiskInfo
 	if err := cloudProps.As(&props); err != nil {
 		return diskCID, bosherr.WrapErrorf(err, "UpdateDisk failed to parse cloud_properties for disk %s", diskCid)

--- a/src/bosh-alicloud-cpi/action/update_disk.go
+++ b/src/bosh-alicloud-cpi/action/update_disk.go
@@ -82,8 +82,8 @@ func (a UpdateDiskMethod) UpdateDisk(diskCID apiv1.DiskCID, newSize int, cloudPr
 
 		// Wait for the spec change to finish before resizing, using the long
 		// ModifyDiskSpec timeout so large-disk conversions don't time out.
-		if _, err := a.disks.WaitForDiskStatus(diskCid, alicloud.DiskStatusAvailable, modifyDiskSpecWaitTimeout, modifyDiskSpecWaitInterval); err != nil {
-			return diskCID, bosherr.WrapErrorf(err, "UpdateDisk WaitForDiskStatus failed for disk %s after spec change", diskCid)
+		if err := a.disks.WaitForDiskSpec(diskCid, string(targetCategory), targetPL, modifyDiskSpecWaitTimeout, modifyDiskSpecWaitInterval); err != nil {
+			return diskCID, bosherr.WrapErrorf(err, "UpdateDisk WaitForDiskSpec failed for disk %s after spec change", diskCid)
 		}
 	}
 

--- a/src/bosh-alicloud-cpi/action/update_disk_test.go
+++ b/src/bosh-alicloud-cpi/action/update_disk_test.go
@@ -5,6 +5,7 @@ package action
 
 import (
 	"bosh-alicloud-cpi/alicloud"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -167,7 +168,22 @@ var _ = Describe("cpi:update_disk", func() {
 				"category": string(alicloud.DiskCategoryCloudESSD),
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("WaitForDiskStatus"))
+			Expect(err.Error()).To(ContainSubstring("WaitForDiskSpec"))
+		})
+
+		It("passes 30m timeout and 10s interval to WaitForDiskSpec", func() {
+			cid, disk := mockContext.NewDisk("")
+			Expect(disk.Category).To(Equal(string(alicloud.DiskCategoryCloudEfficiency)))
+
+			_, err := caller.CallGenericAPIVersion("update_disk", 2, cid, disk.Size*1024, map[string]interface{}{
+				"category": string(alicloud.DiskCategoryCloudESSD),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			opts := *mockContext.WaitForDiskSpecOpts
+			Expect(opts).To(HaveLen(2))
+			Expect(opts[0]).To(Equal(30 * time.Minute))
+			Expect(opts[1]).To(Equal(10 * time.Second))
 		})
 
 		It("returns an error when the disk does not exist", func() {

--- a/src/bosh-alicloud-cpi/action/update_disk_test.go
+++ b/src/bosh-alicloud-cpi/action/update_disk_test.go
@@ -118,6 +118,32 @@ var _ = Describe("cpi:update_disk", func() {
 			updated := mockContext.Disks[cid]
 			Expect(updated.PerformanceLevel).To(Equal("PL1"))
 		})
+
+		It("rejects a performance_level on a non-ESSD category instead of stalling the wait", func() {
+			cid, disk := mockContext.NewDisk("")
+			disk.Category = string(alicloud.DiskCategoryCloudAuto)
+
+			// cloud_auto ignores performance_level; a PL target could never be
+			// observed, so Validate must reject it up front.
+			_, err := caller.CallGenericAPIVersion("update_disk", 2, cid, disk.Size*1024, map[string]interface{}{
+				"category":          string(alicloud.DiskCategoryCloudAuto),
+				"performance_level": "PL1",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("only supported on cloud_essd"))
+		})
+
+		It("rejects a malformed performance_level up front", func() {
+			cid, disk := mockContext.NewDisk("")
+			disk.Category = string(alicloud.DiskCategoryCloudESSD)
+
+			_, err := caller.CallGenericAPIVersion("update_disk", 2, cid, disk.Size*1024, map[string]interface{}{
+				"category":          string(alicloud.DiskCategoryCloudESSD),
+				"performance_level": "PL9",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid performance_level"))
+		})
 	})
 
 	Context("unsupported transitions", func() {
@@ -162,13 +188,35 @@ var _ = Describe("cpi:update_disk", func() {
 
 		It("errors when the disk never returns to Available after the category change", func() {
 			cid, disk := mockContext.NewDisk("")
-			disk.Status = string(alicloud.DiskStatusCreating)
+			// Disk starts Available (entry-wait skipped) as cloud_efficiency, so the
+			// category change to cloud_essd runs. The stall flag makes the mock's
+			// ModifyDiskSpec leave the disk non-Available, so the post-change
+			// WaitForDiskSpec fails.
+			disk.Status = string(alicloud.DiskStatusAvailable)
+			mockContext.Flags["stallModifyDiskSpec"] = true
+			defer delete(mockContext.Flags, "stallModifyDiskSpec")
 
 			_, err := caller.CallGenericAPIVersion("update_disk", 2, cid, disk.Size*1024, map[string]interface{}{
 				"category": string(alicloud.DiskCategoryCloudESSD),
 			})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("WaitForDiskSpec"))
+		})
+
+		It("waits for an in-progress conversion on retry instead of re-issuing ModifyDiskSpec", func() {
+			cid, disk := mockContext.NewDisk("")
+			disk.Category = string(alicloud.DiskCategoryCloudESSD)
+			// Simulate a disk still Modifying from a prior timed-out update_disk call.
+			disk.Status = string(alicloud.DiskStatusCreating)
+
+			// The mock's WaitForDiskStatus fails when status != Available, so this
+			// exercises the entry-wait error path — confirming the guard is reached
+			// and ModifyDiskSpec is not re-issued on a still-Modifying disk.
+			_, err := caller.CallGenericAPIVersion("update_disk", 2, cid, disk.Size*1024, map[string]interface{}{
+				"category": string(alicloud.DiskCategoryCloudESSD),
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not Available on entry"))
 		})
 
 		It("passes 30m timeout and 10s interval to WaitForDiskSpec", func() {

--- a/src/bosh-alicloud-cpi/alicloud/disk_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/disk_manager.go
@@ -46,7 +46,7 @@ type DiskManager interface {
 
 	WaitForDiskStatus(diskCid string, toStatus DiskStatus, opts ...time.Duration) (string, error)
 	WaitForDiskSpec(diskCid, targetCategory, targetPL string, opts ...time.Duration) error
-	ChangeDiskStatus(cid string, toStatus DiskStatus, checkFunc func(*ecs.Disk) (bool, error)) error
+	ChangeDiskStatus(cid string, toStatus DiskStatus, checkFunc func(*ecs.Disk) (bool, error), opts ...time.Duration) error
 
 	GetDiskPath(path, diskId, instanceType string, category DiskCategory) (string, error)
 }
@@ -369,50 +369,22 @@ func (a DiskManagerImpl) WaitForDiskStatus(diskCid string, toStatus DiskStatus, 
 // asynchronous: the disk may still show Available before it transitions to
 // Modifying, so checking category+PL prevents a spurious early return.
 func (a DiskManagerImpl) WaitForDiskSpec(diskCid, targetCategory, targetPL string, opts ...time.Duration) error {
-	invoker := NewInvoker()
+	return a.ChangeDiskStatus(diskCid, DiskStatusAvailable, func(disk *ecs.Disk) (bool, error) {
+		return DiskStatus(disk.Status) == DiskStatusAvailable &&
+			disk.Category == targetCategory &&
+			(targetPL == "" || disk.PerformanceLevel == targetPL), nil
+	}, opts...)
+}
 
-	timeout, interval := WaitTimeout, WaitInterval
+func (a DiskManagerImpl) ChangeDiskStatus(cid string, toStatus DiskStatus, checkFunc func(*ecs.Disk) (bool, error), opts ...time.Duration) error {
+	timeout := ChangeDiskStatusTimeout
+	interval := ChangeDiskStatusSleepInterval
 	if len(opts) >= 1 {
 		timeout = opts[0]
 	}
 	if len(opts) >= 2 {
 		interval = opts[1]
 	}
-
-	ok, err := invoker.RunUntil(timeout, interval, func() (bool, error) {
-		disk, e := a.GetDisk(diskCid)
-		if e != nil {
-			return false, e
-		}
-		if disk == nil {
-			return false, fmt.Errorf("disk missing id=%s", diskCid)
-		}
-		if DiskStatus(disk.Status) != DiskStatusAvailable {
-			a.logger.Info("DiskManager", "WaitForDiskSpec %s: status=%s waiting for Available", diskCid, disk.Status)
-			return false, nil
-		}
-		if disk.Category != targetCategory {
-			a.logger.Info("DiskManager", "WaitForDiskSpec %s: category=%s waiting for %s", diskCid, disk.Category, targetCategory)
-			return false, nil
-		}
-		if targetPL != "" && disk.PerformanceLevel != targetPL {
-			a.logger.Info("DiskManager", "WaitForDiskSpec %s: PL=%s waiting for %s", diskCid, disk.PerformanceLevel, targetPL)
-			return false, nil
-		}
-		return true, nil
-	})
-
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return bosherr.Errorf("WaitForDiskSpec %s to category=%s PL=%s timeout", diskCid, targetCategory, targetPL)
-	}
-	return nil
-}
-
-func (a DiskManagerImpl) ChangeDiskStatus(cid string, toStatus DiskStatus, checkFunc func(*ecs.Disk) (bool, error)) error {
-	timeout := ChangeDiskStatusTimeout
 	for {
 		disk, err := a.GetDisk(cid)
 		if err != nil {
@@ -440,8 +412,8 @@ func (a DiskManagerImpl) ChangeDiskStatus(cid string, toStatus DiskStatus, check
 			a.logger.Info("DiskManager", "changing %s from %s to %s ...", cid, status, toStatus)
 		}
 
-		timeout -= ChangeDiskStatusSleepInterval
-		time.Sleep(ChangeDiskStatusSleepInterval)
+		timeout -= interval
+		time.Sleep(interval)
 		if timeout < 0 {
 			return fmt.Errorf("change disk %s to %s timeout", cid, toStatus)
 		}

--- a/src/bosh-alicloud-cpi/alicloud/disk_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/disk_manager.go
@@ -44,7 +44,7 @@ type DiskManager interface {
 	CreateSnapshot(diskCid string, snapshotName string) (string, error)
 	DeleteSnapshot(snapshotCid string) error
 
-	WaitForDiskStatus(diskCid string, toStatus DiskStatus) (string, error)
+	WaitForDiskStatus(diskCid string, toStatus DiskStatus, opts ...time.Duration) (string, error)
 	ChangeDiskStatus(cid string, toStatus DiskStatus, checkFunc func(*ecs.Disk) (bool, error)) error
 
 	GetDiskPath(path, diskId, instanceType string, category DiskCategory) (string, error)
@@ -318,11 +318,24 @@ func (a DiskManagerImpl) DeleteSnapshot(snapshotCid string) error {
 	})
 }
 
-func (a DiskManagerImpl) WaitForDiskStatus(diskCid string, toStatus DiskStatus) (string, error) {
+// WaitForDiskStatus polls until the disk reaches toStatus. The timeout and
+// interval are optional: WaitForDiskStatus(cid, status) uses the default
+// WaitTimeout/WaitInterval; pass WaitForDiskStatus(cid, status, timeout) or
+// (cid, status, timeout, interval) to override. Extra args beyond two are
+// ignored.
+func (a DiskManagerImpl) WaitForDiskStatus(diskCid string, toStatus DiskStatus, opts ...time.Duration) (string, error) {
 	invoker := NewInvoker()
 
+	timeout, interval := WaitTimeout, WaitInterval
+	if len(opts) >= 1 {
+		timeout = opts[0]
+	}
+	if len(opts) >= 2 {
+		interval = opts[1]
+	}
+
 	result := ""
-	ok, err := invoker.RunUntil(WaitTimeout, WaitInterval, func() (bool, error) {
+	ok, err := invoker.RunUntil(timeout, interval, func() (bool, error) {
 		disk, e := a.GetDisk(diskCid)
 
 		if e != nil {

--- a/src/bosh-alicloud-cpi/alicloud/disk_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/disk_manager.go
@@ -45,6 +45,7 @@ type DiskManager interface {
 	DeleteSnapshot(snapshotCid string) error
 
 	WaitForDiskStatus(diskCid string, toStatus DiskStatus, opts ...time.Duration) (string, error)
+	WaitForDiskSpec(diskCid, targetCategory, targetPL string, opts ...time.Duration) error
 	ChangeDiskStatus(cid string, toStatus DiskStatus, checkFunc func(*ecs.Disk) (bool, error)) error
 
 	GetDiskPath(path, diskId, instanceType string, category DiskCategory) (string, error)
@@ -361,6 +362,53 @@ func (a DiskManagerImpl) WaitForDiskStatus(diskCid string, toStatus DiskStatus, 
 		return "", bosherr.Errorf("WaitForDisk %s to %s timeout", diskCid, toStatus)
 	}
 	return result, nil
+}
+
+// WaitForDiskSpec polls until the disk is Available with the target category and,
+// when targetPL is non-empty, the target performance level. ModifyDiskSpec is
+// asynchronous: the disk may still show Available before it transitions to
+// Modifying, so checking category+PL prevents a spurious early return.
+func (a DiskManagerImpl) WaitForDiskSpec(diskCid, targetCategory, targetPL string, opts ...time.Duration) error {
+	invoker := NewInvoker()
+
+	timeout, interval := WaitTimeout, WaitInterval
+	if len(opts) >= 1 {
+		timeout = opts[0]
+	}
+	if len(opts) >= 2 {
+		interval = opts[1]
+	}
+
+	ok, err := invoker.RunUntil(timeout, interval, func() (bool, error) {
+		disk, e := a.GetDisk(diskCid)
+		if e != nil {
+			return false, e
+		}
+		if disk == nil {
+			return false, fmt.Errorf("disk missing id=%s", diskCid)
+		}
+		if DiskStatus(disk.Status) != DiskStatusAvailable {
+			a.logger.Info("DiskManager", "WaitForDiskSpec %s: status=%s waiting for Available", diskCid, disk.Status)
+			return false, nil
+		}
+		if disk.Category != targetCategory {
+			a.logger.Info("DiskManager", "WaitForDiskSpec %s: category=%s waiting for %s", diskCid, disk.Category, targetCategory)
+			return false, nil
+		}
+		if targetPL != "" && disk.PerformanceLevel != targetPL {
+			a.logger.Info("DiskManager", "WaitForDiskSpec %s: PL=%s waiting for %s", diskCid, disk.PerformanceLevel, targetPL)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return bosherr.Errorf("WaitForDiskSpec %s to category=%s PL=%s timeout", diskCid, targetCategory, targetPL)
+	}
+	return nil
 }
 
 func (a DiskManagerImpl) ChangeDiskStatus(cid string, toStatus DiskStatus, checkFunc func(*ecs.Disk) (bool, error)) error {

--- a/src/bosh-alicloud-cpi/alicloud/disk_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/disk_manager.go
@@ -365,15 +365,25 @@ func (a DiskManagerImpl) WaitForDiskStatus(diskCid string, toStatus DiskStatus, 
 }
 
 // WaitForDiskSpec polls until the disk is Available with the target category and,
-// when targetPL is non-empty, the target performance level. ModifyDiskSpec is
-// asynchronous: the disk may still show Available before it transitions to
-// Modifying, so checking category+PL prevents a spurious early return.
+// when targetPL is non-empty, the target PL. Checking category+PL (not just
+// Available) avoids returning early during the async ModifyDiskSpec transition.
+// On timeout it reports expected-vs-observed spec, so an unsatisfiable target
+// (e.g. a PL that ECS silently ignores) is diagnosable rather than a bare timeout.
 func (a DiskManagerImpl) WaitForDiskSpec(diskCid, targetCategory, targetPL string, opts ...time.Duration) error {
-	return a.ChangeDiskStatus(diskCid, DiskStatusAvailable, func(disk *ecs.Disk) (bool, error) {
+	err := a.ChangeDiskStatus(diskCid, DiskStatusAvailable, func(disk *ecs.Disk) (bool, error) {
 		return DiskStatus(disk.Status) == DiskStatusAvailable &&
 			disk.Category == targetCategory &&
 			(targetPL == "" || disk.PerformanceLevel == targetPL), nil
 	}, opts...)
+	if err != nil {
+		observed := "unknown"
+		if disk, gerr := a.GetDisk(diskCid); gerr == nil && disk != nil {
+			observed = fmt.Sprintf("status=%s category=%s PL=%q", disk.Status, disk.Category, disk.PerformanceLevel)
+		}
+		return bosherr.WrapErrorf(err, "WaitForDiskSpec disk %s: expected category=%s PL=%q, observed %s",
+			diskCid, targetCategory, targetPL, observed)
+	}
+	return nil
 }
 
 func (a DiskManagerImpl) ChangeDiskStatus(cid string, toStatus DiskStatus, checkFunc func(*ecs.Disk) (bool, error), opts ...time.Duration) error {

--- a/src/bosh-alicloud-cpi/mock/context.go
+++ b/src/bosh-alicloud-cpi/mock/context.go
@@ -5,6 +5,7 @@ package mock
 
 import (
 	"bosh-alicloud-cpi/alicloud"
+	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
@@ -29,18 +30,25 @@ type TestContext struct {
 	// which each hold a by-value copy of the struct but share the same map header.
 	// Recognized keys: "failGetDisks", "failDiskPath".
 	Flags map[string]bool
+
+	// WaitForDiskSpecOpts records the opts passed to the most recent WaitForDiskSpec
+	// call, so tests can assert that update_disk passes the expected timeout/interval.
+	// Stored as a pointer so the mock's copy of TestContext writes through to the original.
+	WaitForDiskSpecOpts *[]time.Duration
 }
 
 func NewTestContext(config alicloud.Config) TestContext {
+	opts := make([]time.Duration, 0)
 	return TestContext{
-		config:     config,
-		Disks:      make(map[string]*ecs.Disk),
-		Instances:  make(map[string]*ecs.Instance),
-		Stemcells:  make(map[string]*ecs.Image),
-		Buckets:    make(map[string]*oss.Bucket),
-		OssObjects: make(map[string]string),
-		Snapshots:  make(map[string]string),
-		Flags:      make(map[string]bool),
+		config:              config,
+		Disks:               make(map[string]*ecs.Disk),
+		Instances:           make(map[string]*ecs.Instance),
+		Stemcells:           make(map[string]*ecs.Image),
+		Buckets:             make(map[string]*oss.Bucket),
+		OssObjects:          make(map[string]string),
+		Snapshots:           make(map[string]string),
+		Flags:               make(map[string]bool),
+		WaitForDiskSpecOpts: &opts,
 	}
 }
 

--- a/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 )
@@ -208,7 +209,7 @@ func (a DiskManagerMock) DeleteSnapshot(snapshotCid string) error {
 	return nil
 }
 
-func (a DiskManagerMock) WaitForDiskStatus(diskCid string, toStatus alicloud.DiskStatus) (string, error) {
+func (a DiskManagerMock) WaitForDiskStatus(diskCid string, toStatus alicloud.DiskStatus, opts ...time.Duration) (string, error) {
 	disk, ok := a.mc.Disks[diskCid]
 	if !ok {
 		return "", fmt.Errorf("WaitForDiskStatus disk not exists id=%s", diskCid)

--- a/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
@@ -240,7 +240,7 @@ func (a DiskManagerMock) WaitForDiskSpec(diskCid, targetCategory, targetPL strin
 	return nil
 }
 
-func (a DiskManagerMock) ChangeDiskStatus(cid string, toStatus alicloud.DiskStatus, checkFunc func(disk *ecs.Disk) (bool, error)) error {
+func (a DiskManagerMock) ChangeDiskStatus(cid string, toStatus alicloud.DiskStatus, checkFunc func(disk *ecs.Disk) (bool, error), opts ...time.Duration) error {
 	disk, err := a.GetDisk(cid)
 	if err != nil {
 		return err

--- a/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
@@ -160,6 +160,11 @@ func (a DiskManagerMock) ModifyDiskCategory(diskCid string, category alicloud.Di
 	if performanceLevel != "" {
 		disk.PerformanceLevel = performanceLevel
 	}
+	// Simulate an async conversion that hasn't settled: leave the disk
+	// non-Available so the post-ModifyDiskSpec WaitForDiskSpec has to wait.
+	if a.mc.Flags["stallModifyDiskSpec"] {
+		disk.Status = string(alicloud.DiskStatusCreating)
+	}
 	return nil
 }
 

--- a/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
@@ -220,6 +220,26 @@ func (a DiskManagerMock) WaitForDiskStatus(diskCid string, toStatus alicloud.Dis
 	return disk.Device, nil
 }
 
+// WaitForDiskSpec records opts for test assertions, then checks that the disk is
+// Available with the target category and (when non-empty) the target PL.
+func (a DiskManagerMock) WaitForDiskSpec(diskCid, targetCategory, targetPL string, opts ...time.Duration) error {
+	*a.mc.WaitForDiskSpecOpts = opts
+	disk, ok := a.mc.Disks[diskCid]
+	if !ok {
+		return fmt.Errorf("WaitForDiskSpec disk not exists id=%s", diskCid)
+	}
+	if disk.Status != string(alicloud.DiskStatusAvailable) {
+		return fmt.Errorf("WaitForDiskSpec %s: status=%s is not Available", diskCid, disk.Status)
+	}
+	if disk.Category != targetCategory {
+		return fmt.Errorf("WaitForDiskSpec %s: category=%s does not match target %s", diskCid, disk.Category, targetCategory)
+	}
+	if targetPL != "" && disk.PerformanceLevel != targetPL {
+		return fmt.Errorf("WaitForDiskSpec %s: PL=%s does not match target %s", diskCid, disk.PerformanceLevel, targetPL)
+	}
+	return nil
+}
+
 func (a DiskManagerMock) ChangeDiskStatus(cid string, toStatus alicloud.DiskStatus, checkFunc func(disk *ecs.Disk) (bool, error)) error {
 	disk, err := a.GetDisk(cid)
 	if err != nil {


### PR DESCRIPTION
## Use a longer timeout for the ModifyDiskSpec wait in update_disk

### Problem

update_disk: UpdateDisk WaitForDiskStatus failed for disk d-... after spec change:
WaitForDisk d-... to Available timeout

then, on retry:

detach_disk: detach disk d-... failed: unexpect disk d-... status Modifying

### Root cause

`update_disk` calls `ModifyDiskSpec` (in-place `cloud_efficiency` → `cloud_essd` conversion) and then waits for the disk to return to `Available`. `ModifyDiskSpec` is asynchronous — the disk sits in `Modifying` while AliCloud moves the storage backend.

The wait used the generic `WaitForDiskStatus` timeout (`WaitTimeout`, 600s / 10 min), which is too short for large disks: a 500 GB conversion was observed to exceed 10 min. `update_disk` gave up while the conversion was still running (it completed successfully later — the disk ended up `cloud_essd`, healthy). The director then retried and tried to `detach_disk` a disk still in `Modifying`, producing the second error.

### Fix

Give the `ModifyDiskSpec` wait its own longer timeout (30 min / 10 s poll).

`WaitForDiskStatus` now takes optional variadic `timeout, interval` args (Go has no default parameters):

- `WaitForDiskStatus(cid, status)` — unchanged, uses `WaitTimeout` / `WaitInterval`.
- `WaitForDiskStatus(cid, status, timeout, interval)` — override.

Only `update_disk` opts into the longer budget; `create_vm` and `delete_disk` callers are unchanged and keep the default timeout.

Because `update_disk` now blocks until the disk fully settles, the director no longer proceeds to `detach_disk` while the disk is `Modifying`, so the second error is prevented as a consequence.

### Changes

- `alicloud/disk_manager.go` — `WaitForDiskStatus` accepts optional `timeout, interval` (variadic); falls back to the defaults when omitted.
- `action/update_disk.go` — passes a dedicated 30 min timeout for the post-`ModifyDiskSpec` wait.
- `mock/disk_manager_mock.go` — signature updated to match the interface.

### Testing

`go build ./...`, `go vet`, and the `action` / `mock` / `alicloud` test suites pass. Existing `update_disk` specs (including the wait-failure case) are unchanged.
