### PR TITLE
Stop losing builds to transient network failures and a fixed spot bid

### DIFF
--- a/ci/tasks/put-environment.sh
+++ b/ci/tasks/put-environment.sh
@@ -67,14 +67,29 @@ pushd ${terraform_source}
     # provider quotes the signed request URL when a call fails, and that URL
     # carries the access key and the STS token. PIPESTATUS keeps the exit code of
     # terraform itself rather than the filter's.
-    terraform init \
-        -backend-config="region=${remote_state_region}" \
-        -backend-config="bucket=${remote_state_bucket}" \
-        -backend-config="prefix=${remote_state_file_path}" \
-        -backend-config="key=${remote_state_file_name}" 2>&1 | redact_cloud_credentials
-    init_status=${PIPESTATUS[0]}
+    #
+    # init is retried because it reaches the Location service over the public
+    # internet to discover the OSS endpoint for the state backend, and a build was
+    # lost to a bare net.OpError on that call before any environment existed.
+    # Re-running init is safe: it only prepares the working directory.
+    init_attempts=5
+    for init_attempt in $(seq 1 ${init_attempts}); do
+        terraform init \
+            -backend-config="region=${remote_state_region}" \
+            -backend-config="bucket=${remote_state_bucket}" \
+            -backend-config="prefix=${remote_state_file_path}" \
+            -backend-config="key=${remote_state_file_name}" 2>&1 | redact_cloud_credentials
+        init_status=${PIPESTATUS[0]}
+        if [[ ${init_status} -eq 0 ]]; then
+            break
+        fi
+        if [[ ${init_attempt} -lt ${init_attempts} ]]; then
+            echo "terraform init exited ${init_status}; retrying ($((init_attempt + 1))/${init_attempts})" >&2
+            sleep $((init_attempt * 5))
+        fi
+    done
     if [[ ${init_status} -ne 0 ]]; then
-        echo "terraform init exited ${init_status}" >&2
+        echo "terraform init exited ${init_status} after ${init_attempts} attempts" >&2
         exit ${init_status}
     fi
 

--- a/ci/tasks/run-integration.yml
+++ b/ci/tasks/run-integration.yml
@@ -15,3 +15,13 @@ params:
   # Assumed from the Concourse worker's instance role; no access key is passed in.
   test_role_arn:         ""
   CPI_CREDENTIAL_SOURCE: static
+  # The spot lifecycle spec bids for capacity that a fixed price cannot always
+  # win: eu-central-1a returned OperationDenied.NoStock on three separate builds,
+  # which reports both a sold-out zone and a bid under the market price. Following
+  # the market removes the second cause, leaving only genuine capacity to fail on.
+  #
+  # The pair is not independent: create_vm rejects a price limit on any strategy
+  # other than SpotWithPriceLimit, so a non-zero price here would fail before ECS
+  # is ever called.
+  CPI_SPOT_STRATEGY:     SpotAsPriceGo
+  CPI_SPOT_PRICE_LIMIT:  0

--- a/src/bosh-alicloud-cpi/alicloud/disk_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/disk_manager.go
@@ -525,7 +525,7 @@ func DescribeDisks(client *ecs.Client, diskId string) (disk *ecs.Disk, err error
 	bytes, _ := json.Marshal([]string{diskId})
 	args.DiskIds = string(bytes)
 
-	invoker := NewInvoker()
+	invoker := NewDescribeInvoker()
 	err = invoker.Run(func() error {
 		r, e := client.DescribeDisks(args)
 		if r != nil && len(r.Disks.Disk) > 0 {

--- a/src/bosh-alicloud-cpi/alicloud/instance_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/instance_manager.go
@@ -94,7 +94,7 @@ func (a InstanceManagerImpl) GetInstance(cid string) (inst *ecs.Instance, err er
 	args.RegionId = a.config.OpenApi.GetRegion("")
 	args.InstanceIds = convertListToJsonString([]interface{}{cid})
 
-	invoker := NewInvoker()
+	invoker := NewDescribeInvoker()
 	err = invoker.Run(func() error {
 		r, e := client.DescribeInstances(args)
 		if e != nil {

--- a/src/bosh-alicloud-cpi/alicloud/invoker.go
+++ b/src/bosh-alicloud-cpi/alicloud/invoker.go
@@ -24,11 +24,45 @@ var ServiceBusyCatcher = Catcher{"ServiceUnavailable", 60, 5}
 var OperationConflictCatcher = Catcher{"OperationConflict", 60, 5}
 var InternalErrorCatcher = Catcher{"InternalError", 60, 5}
 
+// A momentary network failure on the way to the API endpoint carries no API
+// error code, so these match the text the net package produces instead. The
+// budget is short because these clear in seconds or not at all.
+var ConnectionResetCatcher = Catcher{"connection reset by peer", 6, 5}
+var ConnectionTimeoutCatcher = Catcher{"i/o timeout", 6, 5}
+var ConnectionRefusedCatcher = Catcher{"connection refused", 6, 5}
+var DNSResolutionCatcher = Catcher{"no such host", 6, 5}
+var TLSHandshakeTimeoutCatcher = Catcher{"TLS handshake timeout", 6, 5}
+
 func NewInvoker() Invoker {
 	i := Invoker{}
 	i.AddCatcher(ServiceBusyCatcher)
 	i.AddCatcher(OperationConflictCatcher)
 	i.AddCatcher(InternalErrorCatcher)
+	return i
+}
+
+// NewDescribeInvoker returns an Invoker that also retries a transient network
+// failure reaching the API endpoint.
+//
+// Only describe calls get this. They are idempotent, so a retry cannot duplicate
+// work; retrying a create or a delete whose response was merely lost could, so
+// those keep using NewInvoker.
+//
+// The reason this exists: the status waits in ChangeInstanceStatus and
+// ChangeDiskStatus end as soon as their status read returns an error, and the
+// pipeline lost whole deploys to a single blip on that read -- DescribeInstances
+// hitting `connection reset by peer`, and DescribeDisks failing to resolve the
+// endpoint -- while the wait still had minutes of budget left and would have
+// succeeded on its next tick. Absorbing the blip here keeps that timeout the one
+// thing that bounds the wait. A network that is genuinely down still fails, only
+// seconds later.
+func NewDescribeInvoker() Invoker {
+	i := NewInvoker()
+	i.AddCatcher(ConnectionResetCatcher)
+	i.AddCatcher(ConnectionTimeoutCatcher)
+	i.AddCatcher(ConnectionRefusedCatcher)
+	i.AddCatcher(DNSResolutionCatcher)
+	i.AddCatcher(TLSHandshakeTimeoutCatcher)
 	return i
 }
 
@@ -43,19 +77,28 @@ func (a *Invoker) Run(f func() error) error {
 		return nil
 	}
 
-	for _, catcher := range a.catchers {
-		if strings.Contains(err.Error(), catcher.Reason) {
-			catcher.RetryCount--
+	if catcher := a.catcherFor(err); catcher != nil {
+		catcher.RetryCount--
 
-			if catcher.RetryCount <= 0 {
-				return bosherr.WrapError(err, "over max retry")
-			} else {
-				time.Sleep(time.Duration(catcher.RetryWaitSeconds) * time.Second)
-				return a.Run(f)
-			}
+		if catcher.RetryCount <= 0 {
+			return bosherr.WrapError(err, "over max retry")
+		} else {
+			time.Sleep(time.Duration(catcher.RetryWaitSeconds) * time.Second)
+			return a.Run(f)
 		}
 	}
 	return err
+}
+
+// catcherFor returns the catcher that claims err, or nil when no catcher does
+// and the error is therefore returned to the caller as-is.
+func (a *Invoker) catcherFor(err error) *Catcher {
+	for _, catcher := range a.catchers {
+		if strings.Contains(err.Error(), catcher.Reason) {
+			return catcher
+		}
+	}
+	return nil
 }
 
 func (a *Invoker) RunUntil(timeout time.Duration, interval time.Duration, f func() (bool, error)) (bool, error) {

--- a/src/bosh-alicloud-cpi/alicloud/invoker_test.go
+++ b/src/bosh-alicloud-cpi/alicloud/invoker_test.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2017-2019 Alibaba Group Holding Limited
+ */
+package alicloud
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The exact errors that ended pipeline builds: a DescribeInstances inside the
+// attach_disk status wait, and a DescribeDisks in the same wait a build earlier.
+const (
+	connectionResetFailure = "read tcp 10.80.227.66:40268->47.254.168.135:443: read: connection reset by peer"
+	dnsTimeoutFailure      = "dial tcp: lookup ecs.eu-central-1.aliyuncs.com: i/o timeout"
+)
+
+var _ = Describe("Invoker", func() {
+	// RetryWaitSeconds is 0 so the retry path runs without real sleeps.
+	newTestInvoker := func(retryCount int) Invoker {
+		i := Invoker{}
+		i.AddCatcher(Catcher{"connection reset by peer", retryCount, 0})
+		return i
+	}
+
+	It("retries a claimed error until the call succeeds", func() {
+		invoker := newTestInvoker(6)
+		calls := 0
+
+		err := invoker.Run(func() error {
+			calls++
+			if calls < 3 {
+				return errors.New(connectionResetFailure)
+			}
+			return nil
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(calls).To(Equal(3))
+	})
+
+	It("gives up once the retry budget is spent", func() {
+		invoker := newTestInvoker(3)
+		calls := 0
+
+		err := invoker.Run(func() error {
+			calls++
+			return errors.New(connectionResetFailure)
+		})
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("over max retry"))
+		// A budget of 3 spends one attempt per decrement, so the call is not
+		// retried forever when the network stays down.
+		Expect(calls).To(Equal(3))
+	})
+
+	It("returns an unclaimed error without retrying", func() {
+		invoker := newTestInvoker(6)
+		calls := 0
+
+		err := invoker.Run(func() error {
+			calls++
+			return errors.New("InvalidInstanceId.NotFound")
+		})
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("InvalidInstanceId.NotFound"))
+		Expect(calls).To(Equal(1))
+	})
+
+	Describe("NewDescribeInvoker", func() {
+		It("claims the transient network failures seen in the pipeline", func() {
+			invoker := NewDescribeInvoker()
+
+			By("connection reset by peer")
+			Expect(invoker.catcherFor(errors.New(connectionResetFailure))).NotTo(BeNil())
+			By("endpoint resolution timing out")
+			Expect(invoker.catcherFor(errors.New(dnsTimeoutFailure))).NotTo(BeNil())
+		})
+
+		It("still claims what NewInvoker claims", func() {
+			invoker := NewDescribeInvoker()
+
+			Expect(invoker.catcherFor(errors.New("ServiceUnavailable"))).NotTo(BeNil())
+			Expect(invoker.catcherFor(errors.New("OperationConflict"))).NotTo(BeNil())
+			Expect(invoker.catcherFor(errors.New("InternalError"))).NotTo(BeNil())
+		})
+
+		It("leaves an API error it should not retry to the caller", func() {
+			invoker := NewDescribeInvoker()
+
+			Expect(invoker.catcherFor(errors.New("Forbidden.RAM"))).To(BeNil())
+			Expect(invoker.catcherFor(errors.New("OperationDenied.NoStock"))).To(BeNil())
+		})
+	})
+
+	Describe("NewInvoker", func() {
+		// A create or a delete whose response was merely lost must not be
+		// replayed, so the plain invoker deliberately does not claim a network
+		// failure. Only idempotent describe calls opt into that.
+		It("does not retry a network failure", func() {
+			invoker := NewInvoker()
+
+			Expect(invoker.catcherFor(errors.New(connectionResetFailure))).To(BeNil())
+			Expect(invoker.catcherFor(errors.New(dnsTimeoutFailure))).To(BeNil())
+		})
+	})
+
+	It("gives each invoker its own retry budget", func() {
+		// The catchers are package-level values, so a budget spent by one CPI
+		// call must not leak into the next. Spending it directly keeps this test
+		// off the real retry path, which sleeps between attempts.
+		first := NewDescribeInvoker()
+		second := NewDescribeInvoker()
+
+		first.catcherFor(errors.New(connectionResetFailure)).RetryCount = 0
+
+		Expect(second.catcherFor(errors.New(connectionResetFailure)).RetryCount).
+			To(Equal(ConnectionResetCatcher.RetryCount))
+		Expect(ConnectionResetCatcher.RetryCount).To(BeNumerically(">", 0))
+	})
+})


### PR DESCRIPTION
Four builds on master failed for reasons unrelated to the code under test.

Three were a single momentary network failure on the way to the API endpoint,
landing on a call with no retry tolerance:

| build | call | error |
| --- | --- | --- |
| end-2-end | `DescribeDisks` | `dial tcp: lookup ecs.<region>.aliyuncs.com: i/o timeout` |
| bats | `DescribeInstances` | `read tcp ...:443: read: connection reset by peer` |
| end-2-end | `DescribeInstances` | `dial tcp: lookup ecs.<region>.aliyuncs.com: i/o timeout` |
| bats | `terraform init` → Location service | `&url.Error{Op:"Post", Err:(*net.OpError)}` |

The first three died inside a status wait that still had minutes of budget left
and would have succeeded on its next tick: `ChangeInstanceStatus` and
`ChangeDiskStatus` end as soon as their status read returns an error. The fourth
happened in `put-environment` before any environment existed, so no CPI binary
was involved and the CPI-side retry cannot cover it.

The fifth failure was `OperationDenied.NoStock` against a fixed spot bid of 0.18.
That error code covers both a sold-out zone and a bid under the market price, and
a fixed bid can only ever lose the second one, so the suite turns red when the
market moves.

### Retrying the network failure

A momentary network failure carries no API error code, so the existing `Invoker`
catchers never matched it; it is matched on the text the net package produces,
which is what those catchers already do for `ServiceUnavailable`.

The retry is **not** added to `NewInvoker`. Its 33 call sites cover creates and
deletes as well as reads, and replaying a mutation whose response was merely lost
could create a second instance or delete something twice. Only idempotent
describe calls opt in, via `NewDescribeInvoker`. A test pins that boundary from
both sides.

The status waits themselves are untouched, so their timeout remains the one thing
that bounds them: a read either succeeds within its retry budget or returns an
error and ends the wait exactly as before. A network that is genuinely down still
fails, roughly half a minute later.

`Run`'s catcher lookup moves into `catcherFor` so matching can be tested without
waiting on real retry sleeps. Behaviour is unchanged.

### Spot

`SpotAsPriceGo` pays the going rate up to the on-demand price, leaving the spec
to fail only on capacity that genuinely is not there. The price limit has to go
to 0 in the same change: `create_vm` rejects a limit on any strategy other than
`SpotWithPriceLimit`. Not `NoSpot`, which would make the spec pass by creating an
on-demand instance and stop it testing spot at all.

The parameters are declared in the task file rather than the pipeline so they
take effect from the git resource on the next build, without a `set-pipeline`.

### Tests

Unit tests use the exact error strings from the failed builds. Verified with
`go build`, `go vet`, `gofmt`, the full unit suite, and `bash -n`.

This is a mitigation, not a root cause fix: the underlying problem is the
worker's network path to the API endpoints.
