### PR TITLE
Use instance types the zone actually has capacity for

### DIFF
--- a/ci/assets/e2e-test-release/cloud-config.yml
+++ b/ci/assets/e2e-test-release/cloud-config.yml
@@ -10,7 +10,7 @@ networks:
 vm_types:
   - name: default
     cloud_properties: &default_cloud_properties
-      instance_type: ecs.sn2.medium
+      instance_type: ecs.g6.large
       availability_zone: ((zone))
   - name: slb_registration_pool
     cloud_properties:
@@ -72,5 +72,5 @@ compilation:
   workers: 1
   network: private
   cloud_properties:
-    instance_type: ecs.sn2.medium
+    instance_type: ecs.g6.large
     availability_zone: ((zone))

--- a/ci/tasks/run-integration.yml
+++ b/ci/tasks/run-integration.yml
@@ -15,18 +15,14 @@ params:
   # Assumed from the Concourse worker's instance role; no access key is passed in.
   test_role_arn:         ""
   CPI_CREDENTIAL_SOURCE: static
-  # The spot lifecycle spec bids for capacity that a fixed price cannot always
-  # win: eu-central-1a returned OperationDenied.NoStock on three separate builds,
-  # which reports both a sold-out zone and a bid under the market price. Following
-  # the market removes the second cause, leaving only genuine capacity to fail on.
+  # eu-central-1a has no c6 spot capacity: the spec kept answering
+  # OperationDenied.NoStock even with the price ruled out, by asking the market
+  # rate rather than a fixed bid. sn1ne.large does have it -- the e2e spot errand
+  # creates one on every build -- and spot capacity is spare on-demand capacity,
+  # so a family that can serve spot can serve this spec.
   #
-  # The pair is not independent: create_vm rejects a price limit on any strategy
-  # other than SpotWithPriceLimit, so a non-zero price here would fail before ECS
-  # is ever called.
-  CPI_SPOT_STRATEGY:     SpotAsPriceGo
-  CPI_SPOT_PRICE_LIMIT:  0
-  # Following the market was not enough: ecs.c6.large kept answering NoStock with
-  # price ruled out, so that zone genuinely has no c6 spot capacity. sn1ne.large
-  # does -- the e2e spot errand creates one on every build -- and spot capacity is
-  # spare on-demand capacity, so a family that can serve spot can serve this spec.
+  # The strategy and the bid stay at their defaults, SpotWithPriceLimit at 0.18.
+  # That is the configuration a customer is most likely to use, and it is the only
+  # thing that exercises spot_price_limit; the e2e errand wins the same capacity
+  # with a fixed bid of 0.10, so 0.18 has room.
   CPI_SPOT_INSTANCE_TYPE: ecs.sn1ne.large

--- a/ci/tasks/run-integration.yml
+++ b/ci/tasks/run-integration.yml
@@ -25,3 +25,8 @@ params:
   # is ever called.
   CPI_SPOT_STRATEGY:     SpotAsPriceGo
   CPI_SPOT_PRICE_LIMIT:  0
+  # Following the market was not enough: ecs.c6.large kept answering NoStock with
+  # price ruled out, so that zone genuinely has no c6 spot capacity. sn1ne.large
+  # does -- the e2e spot errand creates one on every build -- and spot capacity is
+  # spare on-demand capacity, so a family that can serve spot can serve this spec.
+  CPI_SPOT_INSTANCE_TYPE: ecs.sn1ne.large


### PR DESCRIPTION
Both remaining jobs fail with `OperationDenied.NoStock`. Following the spot market (#226) was not enough: with `SpotAsPriceGo` and `SpotPriceLimit:0.000000` in the request, `ecs.c6.large` still answered NoStock. That rules price out and leaves the other condition that error code reports — the zone has no c6 spot capacity.

One build measured all of this at the same moment, in the same zone:

| type | charge | result |
| --- | --- | --- |
| `ecs.sn1ne.large` | spot | creates (e2e spot errand) |
| `ecs.g6.xlarge` | on-demand | creates (director) |
| `ecs.hfc6.xlarge` | on-demand | creates (BATS) |
| `ecs.sn2.medium` | on-demand | **NoStock** (e2e slb errand) |
| `ecs.c6.large` | spot | **NoStock** (integration spot spec) |

The e2e errands move to `g6.large`, a family serving on-demand in that zone right now, rather than to another 2016-era family that will run out again. `slb_registration_pool` inherits it through the YAML anchor, and that is the pool that was failing.

The integration spot spec moves to `sn1ne.large`, the one type measured creating a spot instance here. Spot capacity is spare on-demand capacity, so a family that can serve spot can serve this spec.

Worth stating plainly: this fixes today's shortage, not the reason a shortage breaks the build. `terraform.tf` takes `zones[0]` from an unfiltered `alicloud_zones` lookup, so the pipeline is pinned to one zone with nowhere to go when that zone runs out of a family. Filtering that lookup by the instance types the build needs is the durable fix and is not attempted here.
