### PR TITLE
Finalize release v61.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
 All releases of the BOSH CPI for Alibaba Cloud will be documented in this file.
-## 61.0.0 (Unreleased)
+## 62.0.0 (Unreleased)
+
+## 61.0.0 (August 20, 2026)
 
 FEATURES:
 
@@ -19,10 +21,38 @@ SECURITY:
 - Bumped `credentials-go` to 1.4.12 and `alibaba-cloud-sdk-go` to 1.63.107 for IMDSv2 support ([#218](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/218))
   - Instance metadata is read with a token, so instances that require IMDSv2 are supported
 
+FIXES:
+
+- `delete_stemcell` now deletes the snapshots backing the image ([#219](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/219))
+  - `DeleteImage` does not cascade to them, so every deleted stemcell leaked its snapshots
+  - Waits for the image to be gone first, because a snapshot an image still references cannot be deleted
+  - Logs the ID of every snapshot it could not confirm deleted, so recovery does not need a region-wide scan
+  - Deleting a stemcell that is already gone now succeeds instead of returning an error
+- `update_disk` returns `NotSupported` for an in-place shrink ([#217](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/217))
+  - The director falls back to its copy-and-migrate path, as it did before `update_disk` existed, rather than failing the deploy
+- `update_disk` waits for a category or performance level change to take effect, with a longer timeout ([#224](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/224))
+  - On timeout it reports the disk status and performance level it observed
+- Describe calls retry a transient network failure ([#226](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/226))
+  - A single failed status read used to end a status wait that still had minutes of budget left
+  - Only idempotent describes opt in, through `NewDescribeInvoker`; creates and deletes are never replayed
+
 IMPROVEMENTS:
 
 - `ensure-terminated` waits for instances to terminate, so the terraform destroy that follows no longer fails on a dependency and leaks a VPC
-- The integration suite uses `ecs.c6.large`, whose stock in the test region is reliable
+- The certification pipeline uses instance types the test zone has capacity for, rather than failing on `OperationDenied.NoStock` ([#227](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/227))
+- `terraform init` retries the Location service call it makes before the environment exists ([#226](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/226))
+
+TESTS:
+
+- Added an end-to-end NVMe customer upgrade journey ([#221](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/221))
+  - Upgrades a deployment from a legacy instance type to a 9th-generation NVMe type
+  - Asserts the device paths the CPI reported for the ephemeral and persistent disks, and that the reported link exists on the instance
+  - Asserts the NVMe capability of the image it boots, which `CopyImage` does not inherit and the CPI has to re-apply
+  - Distinguishes an in-place `update_disk` from the director's copy-and-migrate fallback by disk CID
+  - Checks both instance types against `DescribeInstanceTypes` with `NvmeSupport=required` first, so no path assertion can pass vacuously
+- The journey reads image encryption from the system disk mapping `DescribeImages` returns ([#222](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/222), [#223](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/223))
+  - The top-level `Encrypted` field it asserted before is never returned, so the check could not pass
+  - An unencrypted disk now reports `false` instead of being reported as a missing field
 
 ## 60.0.0 (July 29, 2026)
 

--- a/releases/bosh-alicloud-cpi/bosh-alicloud-cpi-61.0.0.yml
+++ b/releases/bosh-alicloud-cpi/bosh-alicloud-cpi-61.0.0.yml
@@ -1,0 +1,28 @@
+name: bosh-alicloud-cpi
+version: 61.0.0
+commit_hash: e89b735
+uncommitted_changes: true
+jobs:
+- name: alicloud_cpi
+  version: 238b1e1c5f7f74070358195fb5901ca33ad6f5004b67ec447324d60f8bd4be14
+  fingerprint: 238b1e1c5f7f74070358195fb5901ca33ad6f5004b67ec447324d60f8bd4be14
+  sha1: sha256:295d68fdd7da4d333b17fcf29313108ddba99c25bb383913c0e6ea3002dc2076
+  packages:
+  - bosh-alicloud-cpi
+packages:
+- name: bosh-alicloud-cpi
+  version: eea8430b314cac0812ff8bc27d21aa48ebdd2bd8ed9a05922f936cc73527cfda
+  fingerprint: eea8430b314cac0812ff8bc27d21aa48ebdd2bd8ed9a05922f936cc73527cfda
+  sha1: sha256:a434e2fd634f222405b04484fc9bf3e3c58b55851adf276b5c80d055bd0ba261
+  dependencies:
+  - golang
+- name: golang
+  version: d5ed0c6b23b5604dcdc9765d33c81e1ed1376732bdfe88065d373aa56b4f9b29
+  fingerprint: d5ed0c6b23b5604dcdc9765d33c81e1ed1376732bdfe88065d373aa56b4f9b29
+  sha1: sha256:f7e36f3f2d5357e7a8ae7090411b8b784d72a441738473d4c132b7e9a74d86e0
+  dependencies: []
+license:
+  version: d35e32db8d971404d5cca86a46140fabed166034a22aaa007b4a3948c758a934
+  fingerprint: d35e32db8d971404d5cca86a46140fabed166034a22aaa007b4a3948c758a934
+  sha1: sha256:12c7e344c47d4c8c1cbe31613255b361970e74773437eec15e985ba9eedc4d50
+no_compression: false

--- a/releases/bosh-alicloud-cpi/index.yml
+++ b/releases/bosh-alicloud-cpi/index.yml
@@ -37,6 +37,8 @@ builds:
     version: 32.0.0
   71bd23dd-954a-43bf-4aeb-8982fd1aacc1:
     version: 27.0.0
+  721d0d74-5b0d-4e9d-5c1c-1079f2e2c4d0:
+    version: 61.0.0
   75146091-e256-45c2-7396-c66e23ec9cb4:
     version: "10"
   82785ae7-c98e-4456-7b99-50d1d2084a76:


### PR DESCRIPTION
Finalizes v61.0.0 from the green master build (e89b735).

Adds the final release manifest and index entry, and fills in the 61.0.0 CHANGELOG with the PRs merged since v60.0.0 (#217, #219, #221, #222, #223, #224, #226, #227) alongside the ECS RAM role work (#218) already recorded.

Same three-file shape as prior finalize PRs (#216, #213): CHANGELOG.md, releases/bosh-alicloud-cpi/index.yml, releases/bosh-alicloud-cpi/bosh-alicloud-cpi-61.0.0.yml.