### PR TITLE
Raise update_disk timeout to 60 mins

### DIFF
--- a/src/bosh-alicloud-cpi/action/detach_disk.go
+++ b/src/bosh-alicloud-cpi/action/detach_disk.go
@@ -38,6 +38,8 @@ func (a DetachDiskMethod) DetachDisk(vmCID apiv1.VMCID, diskCID apiv1.DiskCID) e
 			return true, nil
 		case alicloud.DiskStatusDetaching:
 			return false, nil
+		case alicloud.DiskStatusModifying:
+			return false, nil
 		default:
 			return false, fmt.Errorf("unexpect disk %s status %s", diskCid, disk.Status)
 		}

--- a/src/bosh-alicloud-cpi/action/detach_disk.go
+++ b/src/bosh-alicloud-cpi/action/detach_disk.go
@@ -39,7 +39,7 @@ func (a DetachDiskMethod) DetachDisk(vmCID apiv1.VMCID, diskCID apiv1.DiskCID) e
 		case alicloud.DiskStatusDetaching:
 			return false, nil
 		case alicloud.DiskStatusModifying:
-			return false, nil
+			return false, fmt.Errorf("disk %s is Modifying (mid-conversion), retry once the conversion completes", diskCid)
 		default:
 			return false, fmt.Errorf("unexpect disk %s status %s", diskCid, disk.Status)
 		}

--- a/src/bosh-alicloud-cpi/action/detach_disk_test.go
+++ b/src/bosh-alicloud-cpi/action/detach_disk_test.go
@@ -21,6 +21,19 @@ var _ = Describe("cpi:detach_disk", func() {
 		Expect(disk.InstanceId).Should(Equal(""))
 	})
 
+	It("fails immediately when disk is Modifying", func() {
+		// "Modifying" is undocumented in the AliCloud DescribeDisks enum but
+		// observed in production (Task 26321593). This test pins the string
+		// literal via DiskStatusModifying so a casing/spelling change is caught.
+		instCid, _ := mockContext.NewInstance()
+		diskCid, disk := mockContext.NewDisk(instCid)
+		disk.Status = string(alicloud.DiskStatusModifying)
+
+		_, err := caller.Call("detach_disk", instCid, diskCid)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Modifying"))
+	})
+
 	//It("can attach disk with right registry", func() {
 	//	By("attach disk")
 	//	diskCid, _ := mockContext.NewDisk()

--- a/src/bosh-alicloud-cpi/action/update_disk.go
+++ b/src/bosh-alicloud-cpi/action/update_disk.go
@@ -15,7 +15,7 @@ import (
 // longer than the generic WaitForDiskStatus timeout (600s). Give the spec-change
 // wait its own budget, matching the 30 min the Ruby bootstrap-bosh migration uses.
 const (
-	modifyDiskSpecWaitTimeout  = 30 * time.Minute
+	modifyDiskSpecWaitTimeout  = 60 * time.Minute
 	modifyDiskSpecWaitInterval = 10 * time.Second
 )
 

--- a/src/bosh-alicloud-cpi/action/update_disk.go
+++ b/src/bosh-alicloud-cpi/action/update_disk.go
@@ -15,8 +15,9 @@ import (
 // longer than the generic WaitForDiskStatus timeout (600s). Give the spec-change
 // wait its own budget, matching the 30 min the Ruby bootstrap-bosh migration uses.
 const (
-	modifyDiskSpecWaitTimeout  = 60 * time.Minute
-	modifyDiskSpecWaitInterval = 10 * time.Second
+	modifyDiskSpecWaitTimeout      = 60 * time.Minute // post-ModifyDiskSpec wait
+	modifyDiskSpecEntryWaitTimeout = 10 * time.Minute // entry-guard: wait for a prior conversion to settle
+	modifyDiskSpecWaitInterval     = 10 * time.Second
 )
 
 type UpdateDiskMethod struct {
@@ -44,7 +45,7 @@ func (a UpdateDiskMethod) UpdateDisk(diskCID apiv1.DiskCID, newSize int, cloudPr
 	// to settle to Available before reading category/PL, so we don't re-issue
 	// ModifyDiskSpec on a disk that is mid-conversion.
 	if alicloud.DiskStatus(disk.Status) != alicloud.DiskStatusAvailable {
-		if _, err := a.disks.WaitForDiskStatus(diskCid, alicloud.DiskStatusAvailable, modifyDiskSpecWaitTimeout, modifyDiskSpecWaitInterval); err != nil {
+		if _, err := a.disks.WaitForDiskStatus(diskCid, alicloud.DiskStatusAvailable, modifyDiskSpecEntryWaitTimeout, modifyDiskSpecWaitInterval); err != nil {
 			return diskCID, bosherr.WrapErrorf(err, "UpdateDisk disk %s not Available on entry", diskCid)
 		}
 		disk, err = a.disks.GetDisk(diskCid)

--- a/src/bosh-alicloud-cpi/action/update_disk.go
+++ b/src/bosh-alicloud-cpi/action/update_disk.go
@@ -13,7 +13,7 @@ import (
 
 // ModifyDiskSpec is asynchronous and can run for many minutes on large disks —
 // longer than the generic WaitForDiskStatus timeout (600s). Give the spec-change
-// wait its own budget, matching the 30 min the Ruby bootstrap-bosh migration uses.
+// wait its own budget, matching the 60 min the Ruby bootstrap-bosh migration uses.
 const (
 	modifyDiskSpecWaitTimeout      = 60 * time.Minute // post-ModifyDiskSpec wait
 	modifyDiskSpecEntryWaitTimeout = 10 * time.Minute // entry-guard: wait for a prior conversion to settle

--- a/src/bosh-alicloud-cpi/action/update_disk_test.go
+++ b/src/bosh-alicloud-cpi/action/update_disk_test.go
@@ -219,7 +219,7 @@ var _ = Describe("cpi:update_disk", func() {
 			Expect(err.Error()).To(ContainSubstring("not Available on entry"))
 		})
 
-		It("passes 30m timeout and 10s interval to WaitForDiskSpec", func() {
+		It("passes 60m timeout and 10s interval to WaitForDiskSpec", func() {
 			cid, disk := mockContext.NewDisk("")
 			Expect(disk.Category).To(Equal(string(alicloud.DiskCategoryCloudEfficiency)))
 
@@ -230,7 +230,7 @@ var _ = Describe("cpi:update_disk", func() {
 
 			opts := *mockContext.WaitForDiskSpecOpts
 			Expect(opts).To(HaveLen(2))
-			Expect(opts[0]).To(Equal(30 * time.Minute))
+			Expect(opts[0]).To(Equal(60 * time.Minute))
 			Expect(opts[1]).To(Equal(10 * time.Second))
 		})
 

--- a/src/bosh-alicloud-cpi/action/update_disk_test.go
+++ b/src/bosh-alicloud-cpi/action/update_disk_test.go
@@ -234,6 +234,24 @@ var _ = Describe("cpi:update_disk", func() {
 			Expect(opts[1]).To(Equal(10 * time.Second))
 		})
 
+		It("passes 10m timeout and 10s interval to entry-wait WaitForDiskStatus", func() {
+			cid, disk := mockContext.NewDisk("")
+			disk.Category = string(alicloud.DiskCategoryCloudESSD)
+			// Non-Available status triggers the entry-guard. WaitForDiskStatus will
+			// fail (mock checks status synchronously), but opts are recorded before
+			// the check so we can assert the constants regardless.
+			disk.Status = string(alicloud.DiskStatusCreating)
+
+			_, _ = caller.CallGenericAPIVersion("update_disk", 2, cid, disk.Size*1024, map[string]interface{}{
+				"category": string(alicloud.DiskCategoryCloudESSD),
+			})
+
+			opts := *mockContext.WaitForDiskStatusOpts
+			Expect(opts).To(HaveLen(2))
+			Expect(opts[0]).To(Equal(10 * time.Minute))
+			Expect(opts[1]).To(Equal(10 * time.Second))
+		})
+
 		It("returns an error when the disk does not exist", func() {
 			_, err := caller.CallGenericAPIVersion("update_disk", 2, "non-existent-disk", 20480, map[string]interface{}{
 				"category": string(alicloud.DiskCategoryCloudESSD),

--- a/src/bosh-alicloud-cpi/alicloud/common.go
+++ b/src/bosh-alicloud-cpi/alicloud/common.go
@@ -55,6 +55,7 @@ const (
 	DiskStatusAttaching = DiskStatus("Attaching")
 	DiskStatusDetaching = DiskStatus("Detaching")
 	DiskStatusCreating  = DiskStatus("Creating")
+	DiskStatusModifying = DiskStatus("Modifying")
 	DiskStatusReIniting = DiskStatus("ReIniting")
 	DiskStatusAll       = DiskStatus("All") //Default
 )

--- a/src/bosh-alicloud-cpi/mock/context.go
+++ b/src/bosh-alicloud-cpi/mock/context.go
@@ -40,11 +40,16 @@ type TestContext struct {
 	// call, so tests can assert the query keys create_vm builds. Stored as a pointer
 	// so the mock's copy of TestContext writes through to the original.
 	CreateInstanceArgs *map[string]interface{}
+
+	// WaitForDiskStatusOpts records the opts passed to the most recent WaitForDiskStatus call.
+	WaitForDiskStatusOpts *[]time.Duration
 }
 
 func NewTestContext(config alicloud.Config) TestContext {
 	opts := make([]time.Duration, 0)
 	createArgs := make(map[string]interface{})
+	specOpts := make([]time.Duration, 0)
+	statusOpts := make([]time.Duration, 0)
 	return TestContext{
 		config:              config,
 		Disks:               make(map[string]*ecs.Disk),
@@ -56,6 +61,8 @@ func NewTestContext(config alicloud.Config) TestContext {
 		Flags:               make(map[string]bool),
 		WaitForDiskSpecOpts: &opts,
 		CreateInstanceArgs:  &createArgs,
+		WaitForDiskSpecOpts:   &specOpts,
+		WaitForDiskStatusOpts: &statusOpts,
 	}
 }
 

--- a/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
@@ -215,6 +215,7 @@ func (a DiskManagerMock) DeleteSnapshot(snapshotCid string) error {
 }
 
 func (a DiskManagerMock) WaitForDiskStatus(diskCid string, toStatus alicloud.DiskStatus, opts ...time.Duration) (string, error) {
+	*a.mc.WaitForDiskStatusOpts = opts
 	disk, ok := a.mc.Disks[diskCid]
 	if !ok {
 		return "", fmt.Errorf("WaitForDiskStatus disk not exists id=%s", diskCid)


### PR DESCRIPTION
Tolerate Modifying status in detach_disk; bound update_disk worst-case wall time

A 2TB disk conversion can outlast the prior 30m WaitForDiskSpec budget. When the director retried the deploy it called detach_disk first, which hard-failed with an undocumented status:

```
detach disk d-uf62i7d6aovlj2b958bl from i-uf6el7xkbsn41ia1z664 failed: unexpect disk d-uf62i7d6aovlj2b958bl status Modifying
```

The preceding update_disk failure (confirming the string spelling in production):

```
UpdateDisk WaitForDiskSpec failed for disk d-uf62i7d6aovlj2b958bl after spec change: WaitForDiskSpec disk d-uf62i7d6aovlj2b958bl: expected category=cloud_essd PL="", observed status=Modifying category=cloud_essd PL="PL1": change disk d-uf62i7d6aovlj2b958bl to Available timeout
```

Changes:

- Add `DiskStatusModifying = DiskStatus("Modifying")` constant, confirmed from the log above
- `detach_disk`: handle `Modifying` in the switch with an immediate actionable error — detach has no knowledge of why the disk is Modifying and should not wait; the operator retries the deploy once the conversion completes
- `update_disk`: add separate `modifyDiskSpecEntryWaitTimeout = 10m` for the entry-guard; the post-spec wait keeps 60m. Worst-case wall time is now 70 min instead of 120 min.
- Tests: pin the `Modifying` literal in `detach_disk_test.go`; assert entry-guard passes 10m and post-spec wait passes 60m