### PR TITLE
Support PrivatePoolOptions when creating an instance

### DIFF
--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -65,6 +65,14 @@ type InstanceProps struct {
 	SpotPriceLimit       float64                        `json:"spot_price_limit"`
 	RamRoleName          string                         `json:"ram_role_name"`
 	StemcellId           string                         `json:"stemcell_id"`
+	PrivatePoolOptions   PrivatePoolOptions             `json:"private_pool_options"`
+}
+
+// Private pool capacity produced by an elasticity assurance or a capacity
+// reservation: https://help.aliyun.com/zh/ecs/developer-reference/api-ecs-2014-05-26-createinstance
+type PrivatePoolOptions struct {
+	MatchCriteria alicloud.PrivatePoolMatchCriteriaType `json:"match_criteria"`
+	Id            string                                `json:"id"`
 }
 
 type CreateVMMethod struct {
@@ -170,6 +178,11 @@ func (a CreateVMMethod) createVM(
 		return apiv1.VMCID{}, nil, bosherr.WrapError(err, "invalid spot properties ")
 	}
 
+	// private pool props
+	if err := validatePrivatePoolProps(instProps); err != nil {
+		return apiv1.VMCID{}, nil, bosherr.WrapError(err, "invalid private pool properties ")
+	}
+
 	// config vm charge type
 	if instProps.ChargeType == "PrePaid" {
 		createInstanceRequest["InstanceChargeType"] = "PrePaid"
@@ -216,6 +229,15 @@ func (a CreateVMMethod) createVM(
 	createInstanceRequest["SpotStrategy"] = string(instProps.SpotStrategy)
 	createInstanceRequest["SpotPriceLimit"] = requests.NewFloat(instProps.SpotPriceLimit)
 	createInstanceRequest["RamRoleName"] = instProps.RamRoleName
+
+	// Leave the private pool keys out entirely when unset, so ECS applies its
+	// own default (None) and existing deployments keep their behaviour.
+	if instProps.PrivatePoolOptions.MatchCriteria != "" {
+		createInstanceRequest["PrivatePoolOptions.MatchCriteria"] = string(instProps.PrivatePoolOptions.MatchCriteria)
+		if id := strings.TrimSpace(instProps.PrivatePoolOptions.Id); id != "" {
+			createInstanceRequest["PrivatePoolOptions.Id"] = id
+		}
+	}
 
 	// fill disks
 	disks, err := NewDisksWithProps(instProps.SystemDisk, instProps.EphemeralDisk)
@@ -528,6 +550,39 @@ func validateSpotProps(p InstanceProps) error {
 
 	if limitPrice != 0 && strategy != string(alicloud.SpotWithPriceLimit) {
 		return fmt.Errorf("spot limit price only support 'SpotWithPriceLimit' strategy")
+	}
+	return nil
+}
+
+func validatePrivatePoolProps(p InstanceProps) error {
+	criteria := string(p.PrivatePoolOptions.MatchCriteria)
+	id := strings.TrimSpace(p.PrivatePoolOptions.Id)
+
+	if criteria == "" {
+		if id != "" {
+			return fmt.Errorf("private pool id requires match_criteria '%s'", alicloud.PrivatePoolTarget)
+		}
+		return nil
+	}
+
+	criteriaArr := []string{string(alicloud.PrivatePoolOpen), string(alicloud.PrivatePoolTarget), string(alicloud.PrivatePoolNone)}
+	if err := validAllowedStringValues(criteria, criteriaArr); err != nil {
+		return err
+	}
+
+	if criteria == string(alicloud.PrivatePoolTarget) {
+		if id == "" {
+			return fmt.Errorf("private pool id is required by match_criteria '%s'", alicloud.PrivatePoolTarget)
+		}
+	} else if id != "" {
+		return fmt.Errorf("private pool id only support '%s' match_criteria", alicloud.PrivatePoolTarget)
+	}
+
+	// ECS rejects a private pool on a spot instance with SpotNotSupported, so
+	// fail before the create call rather than after it.
+	if criteria != string(alicloud.PrivatePoolNone) &&
+		p.SpotStrategy != "" && p.SpotStrategy != alicloud.NoSpot {
+		return fmt.Errorf("match_criteria '%s' does not support the spot strategy '%s'", criteria, p.SpotStrategy)
 	}
 	return nil
 }

--- a/src/bosh-alicloud-cpi/action/create_vm_test.go
+++ b/src/bosh-alicloud-cpi/action/create_vm_test.go
@@ -378,6 +378,16 @@ var _ = Describe("create_vm", func() {
 	})
 
 	Context("private pool options", func() {
+		// The rules checked here mirror what ECS itself rejects, confirmed against
+		// CreateInstance with DryRun set: Target with no id comes back as
+		// MissingParameter.PrivatePoolOptionsId, an id under any other criteria as
+		// Invalid.PrivatePoolOptionsId, and a private pool on a spot instance as
+		// SpotNotSupported. Checking those locally saves a round trip.
+		//
+		// For a criteria outside the enum it saves more than a round trip: ECS
+		// answers UnknownError, which says nothing about which field is wrong. That
+		// is the reason to keep this validation rather than lean on ECS.
+
 		// validateFor runs the validation against a cloud_properties fragment, so it
 		// covers the json schema and the validation rules together.
 		validateFor := func(cloudProps string) error {
@@ -392,6 +402,13 @@ var _ = Describe("create_vm", func() {
 
 		It("accepts Target with an id", func() {
 			Expect(validateFor(`{"private_pool_options": {"match_criteria": "Target", "id": "eap-bp67acfmxazb4"}}`)).To(Succeed())
+		})
+
+		// A private pool id names either an elasticity assurance (eap-) or a
+		// capacity reservation (crp-). Both are private pools to ECS, so neither
+		// prefix is treated as more valid than the other here.
+		It("accepts Target with a capacity reservation id", func() {
+			Expect(validateFor(`{"private_pool_options": {"match_criteria": "Target", "id": "crp-bp67acfmxazb4"}}`)).To(Succeed())
 		})
 
 		It("accepts None", func() {
@@ -434,6 +451,29 @@ var _ = Describe("create_vm", func() {
 				"private_pool_options": {"match_criteria": "None"},
 				"spot_strategy": "SpotAsPriceGo"
 			}`)).To(Succeed())
+		})
+
+		It("rejects an id on None, which ignores it", func() {
+			Expect(validateFor(`{"private_pool_options": {"match_criteria": "None", "id": "eap-bp67acfmxazb4"}}`)).To(
+				MatchError(ContainSubstring("only support 'Target'")))
+		})
+
+		// An id of nothing but whitespace is an id the operator did not supply, and
+		// treating it as one would send ECS a blank Target and fail there instead of
+		// here. Both the check and the request mapping trim before deciding.
+		Describe("an id of only whitespace", func() {
+			It("does not satisfy Target", func() {
+				Expect(validateFor(`{"private_pool_options": {"match_criteria": "Target", "id": "   "}}`)).To(
+					MatchError(ContainSubstring("id is required")))
+			})
+
+			It("is not held against Open", func() {
+				Expect(validateFor(`{"private_pool_options": {"match_criteria": "Open", "id": "   "}}`)).To(Succeed())
+			})
+
+			It("does not on its own require a match_criteria", func() {
+				Expect(validateFor(`{"private_pool_options": {"id": "   "}}`)).To(Succeed())
+			})
 		})
 
 		Context("the query create_vm sends to ECS", func() {
@@ -487,6 +527,38 @@ var _ = Describe("create_vm", func() {
 				Expect(args).NotTo(HaveKey("PrivatePoolOptions.Id"))
 			})
 
+			It("carries a capacity reservation id", func() {
+				r := caller.Run(buildCreateVM(`,
+					"private_pool_options": {"match_criteria": "Target", "id": "crp-bp67acfmxazb4"}`))
+				Expect(r.GetError()).NotTo(HaveOccurred())
+
+				args := *mockContext.CreateInstanceArgs
+				Expect(args).To(HaveKeyWithValue("PrivatePoolOptions.MatchCriteria", "Target"))
+				Expect(args).To(HaveKeyWithValue("PrivatePoolOptions.Id", "crp-bp67acfmxazb4"))
+			})
+
+			// None is also what ECS falls back to on its own, but asking for it and
+			// saying nothing are different requests: an explicit None overrides a
+			// pool the account has set as its default.
+			It("sends None when None is what was asked for", func() {
+				r := caller.Run(buildCreateVM(`,
+					"private_pool_options": {"match_criteria": "None"}`))
+				Expect(r.GetError()).NotTo(HaveOccurred())
+
+				args := *mockContext.CreateInstanceArgs
+				Expect(args).To(HaveKeyWithValue("PrivatePoolOptions.MatchCriteria", "None"))
+				Expect(args).NotTo(HaveKey("PrivatePoolOptions.Id"))
+			})
+
+			It("trims the id, which ECS would otherwise reject", func() {
+				r := caller.Run(buildCreateVM(`,
+					"private_pool_options": {"match_criteria": "Target", "id": "  eap-bp67acfmxazb4  "}`))
+				Expect(r.GetError()).NotTo(HaveOccurred())
+
+				args := *mockContext.CreateInstanceArgs
+				Expect(args).To(HaveKeyWithValue("PrivatePoolOptions.Id", "eap-bp67acfmxazb4"))
+			})
+
 			It("omits both keys when unset, leaving the ECS default in place", func() {
 				r := caller.Run(buildCreateVM(``))
 				Expect(r.GetError()).NotTo(HaveOccurred())
@@ -494,6 +566,20 @@ var _ = Describe("create_vm", func() {
 				args := *mockContext.CreateInstanceArgs
 				Expect(args).NotTo(HaveKey("PrivatePoolOptions.MatchCriteria"))
 				Expect(args).NotTo(HaveKey("PrivatePoolOptions.Id"))
+			})
+
+			// The checks above call the validation directly, so none of them prove
+			// create_vm reaches it. This runs the whole method on properties ECS
+			// would reject and expects the create call never to happen.
+			It("does not reach ECS when the properties do not validate", func() {
+				*mockContext.CreateInstanceArgs = map[string]interface{}{}
+
+				r := caller.Run(buildCreateVM(`,
+					"private_pool_options": {"match_criteria": "Target"}`))
+
+				Expect(r.GetError()).To(HaveOccurred())
+				Expect(r.GetError().Error()).To(ContainSubstring("id is required"))
+				Expect(*mockContext.CreateInstanceArgs).To(BeEmpty())
 			})
 		})
 	})

--- a/src/bosh-alicloud-cpi/action/create_vm_test.go
+++ b/src/bosh-alicloud-cpi/action/create_vm_test.go
@@ -4,6 +4,8 @@
 package action
 
 import (
+	"encoding/json"
+
 	"bosh-alicloud-cpi/mock"
 
 	. "github.com/onsi/ginkgo"
@@ -372,6 +374,127 @@ var _ = Describe("create_vm", func() {
 			r := caller.Run(buildCreateVM("ecs.c9i.xlarge"))
 			Expect(r.GetError()).To(HaveOccurred())
 			Expect(mockContext.Instances).To(HaveLen(before), "the created instance should have been deleted")
+		})
+	})
+
+	Context("private pool options", func() {
+		// validateFor runs the validation against a cloud_properties fragment, so it
+		// covers the json schema and the validation rules together.
+		validateFor := func(cloudProps string) error {
+			var props InstanceProps
+			Expect(json.Unmarshal([]byte(cloudProps), &props)).To(Succeed())
+			return validatePrivatePoolProps(props)
+		}
+
+		It("accepts Open without an id", func() {
+			Expect(validateFor(`{"private_pool_options": {"match_criteria": "Open"}}`)).To(Succeed())
+		})
+
+		It("accepts Target with an id", func() {
+			Expect(validateFor(`{"private_pool_options": {"match_criteria": "Target", "id": "eap-bp67acfmxazb4"}}`)).To(Succeed())
+		})
+
+		It("accepts None", func() {
+			Expect(validateFor(`{"private_pool_options": {"match_criteria": "None"}}`)).To(Succeed())
+		})
+
+		It("accepts cloud_properties without private_pool_options", func() {
+			Expect(validateFor(`{"instance_type": "ecs.n4.large"}`)).To(Succeed())
+		})
+
+		It("rejects Target without an id", func() {
+			Expect(validateFor(`{"private_pool_options": {"match_criteria": "Target"}}`)).To(
+				MatchError(ContainSubstring("id is required")))
+		})
+
+		It("rejects an id on Open, which ignores it", func() {
+			Expect(validateFor(`{"private_pool_options": {"match_criteria": "Open", "id": "eap-bp67acfmxazb4"}}`)).To(
+				MatchError(ContainSubstring("only support 'Target'")))
+		})
+
+		It("rejects an id without a match_criteria", func() {
+			Expect(validateFor(`{"private_pool_options": {"id": "eap-bp67acfmxazb4"}}`)).To(
+				MatchError(ContainSubstring("requires match_criteria 'Target'")))
+		})
+
+		It("rejects an unknown match_criteria", func() {
+			Expect(validateFor(`{"private_pool_options": {"match_criteria": "open"}}`)).To(
+				MatchError(ContainSubstring("is not in array")))
+		})
+
+		It("rejects a private pool on a spot instance, which ECS does not support", func() {
+			Expect(validateFor(`{
+				"private_pool_options": {"match_criteria": "Open"},
+				"spot_strategy": "SpotAsPriceGo"
+			}`)).To(MatchError(ContainSubstring("does not support the spot strategy")))
+		})
+
+		It("allows None on a spot instance", func() {
+			Expect(validateFor(`{
+				"private_pool_options": {"match_criteria": "None"},
+				"spot_strategy": "SpotAsPriceGo"
+			}`)).To(Succeed())
+		})
+
+		Context("the query create_vm sends to ECS", func() {
+			buildCreateVM := func(privatePoolOptions string) []byte {
+				return mock.NewBuilder(`{
+					"method": "create_vm",
+					"arguments": [
+						"243bf6fc-8f26-4aef-b40f-824763fcdfa2",
+						"m-2zehhdtfg22hq46reabf",
+						{
+							"instance_type": "ecs.n4.xlarge"` + privatePoolOptions + `
+						},
+						{
+							"cf1": {
+								"type": "manual",
+								"ip": "10.0.16.109",
+								"netmask": "255.255.240.0",
+								"cloud_properties": {
+									"security_group_ids": ["sg-2ze2ct08gslmnwyv8c1k"],
+									"vswitch_id": "vpc-2ze3owai4kbkv2yf6nivg"
+								},
+								"default": ["dns", "gateway"],
+								"dns": ["10.0.16.2"],
+								"gateway": "10.0.16.1"
+							}
+						},
+						[],
+						{ "bosh": { "group": "g" } }
+					],
+					"context": { "director_uuid": "879e2edf-a9c4-4d2e-be8c-6b23dc530008" }
+				}`).ToBytes()
+			}
+
+			It("carries the documented ECS query keys", func() {
+				r := caller.Run(buildCreateVM(`,
+					"private_pool_options": {"match_criteria": "Target", "id": "eap-bp67acfmxazb4"}`))
+				Expect(r.GetError()).NotTo(HaveOccurred())
+
+				args := *mockContext.CreateInstanceArgs
+				Expect(args).To(HaveKeyWithValue("PrivatePoolOptions.MatchCriteria", "Target"))
+				Expect(args).To(HaveKeyWithValue("PrivatePoolOptions.Id", "eap-bp67acfmxazb4"))
+			})
+
+			It("omits the id on Open", func() {
+				r := caller.Run(buildCreateVM(`,
+					"private_pool_options": {"match_criteria": "Open"}`))
+				Expect(r.GetError()).NotTo(HaveOccurred())
+
+				args := *mockContext.CreateInstanceArgs
+				Expect(args).To(HaveKeyWithValue("PrivatePoolOptions.MatchCriteria", "Open"))
+				Expect(args).NotTo(HaveKey("PrivatePoolOptions.Id"))
+			})
+
+			It("omits both keys when unset, leaving the ECS default in place", func() {
+				r := caller.Run(buildCreateVM(``))
+				Expect(r.GetError()).NotTo(HaveOccurred())
+
+				args := *mockContext.CreateInstanceArgs
+				Expect(args).NotTo(HaveKey("PrivatePoolOptions.MatchCriteria"))
+				Expect(args).NotTo(HaveKey("PrivatePoolOptions.Id"))
+			})
 		})
 	})
 })

--- a/src/bosh-alicloud-cpi/alicloud/common.go
+++ b/src/bosh-alicloud-cpi/alicloud/common.go
@@ -81,6 +81,15 @@ const (
 	SpotAsPriceGo      = SpotStrategyType("SpotAsPriceGo")
 )
 
+type PrivatePoolMatchCriteriaType string
+
+// Constants of PrivatePoolMatchCriteriaType
+const (
+	PrivatePoolOpen   = PrivatePoolMatchCriteriaType("Open")
+	PrivatePoolTarget = PrivatePoolMatchCriteriaType("Target")
+	PrivatePoolNone   = PrivatePoolMatchCriteriaType("None")
+)
+
 type ImageFormatType string
 
 const (

--- a/src/bosh-alicloud-cpi/alicloud/create_instance_query_test.go
+++ b/src/bosh-alicloud-cpi/alicloud/create_instance_query_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2017-2019 Alibaba Group Holding Limited
+ */
+package alicloud
+
+import (
+	openapiutil "github.com/alibabacloud-go/openapi-util/service"
+	"github.com/alibabacloud-go/tea/tea"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// CreateInstance hands its query map to openapiutil.Query on the way to the
+// wire, and the private pool parameters are the first ones this CPI sends whose
+// ECS names contain a dot.
+//
+// Nothing else covers that step. The create_vm tests stop at
+// InstanceManagerMock, which records the query map and never reaches the SDK, so
+// a Query that dropped or rewrote a dotted key would leave every one of them
+// green while the instances quietly kept coming out of the public pool.
+var _ = Describe("the query CreateInstance sends", func() {
+	stringValues := func(in map[string]*string) map[string]string {
+		out := map[string]string{}
+		for k, v := range in {
+			out[k] = tea.StringValue(v)
+		}
+		return out
+	}
+
+	It("keeps the private pool parameter names intact", func() {
+		out := openapiutil.Query(map[string]interface{}{
+			"RegionId":                         "cn-hangzhou",
+			"PrivatePoolOptions.MatchCriteria": "Target",
+			"PrivatePoolOptions.Id":            "eap-bp67acfmxazb4",
+		})
+
+		Expect(stringValues(out)).To(Equal(map[string]string{
+			"RegionId":                         "cn-hangzhou",
+			"PrivatePoolOptions.MatchCriteria": "Target",
+			"PrivatePoolOptions.Id":            "eap-bp67acfmxazb4",
+		}))
+	})
+
+	// Query flattens a nested value by joining the levels with a dot, so naming
+	// the parameter in its already-flattened form is not a shortcut past the SDK:
+	// it is the same request the nested form produces. If that ever stops being
+	// true, this test fails rather than a deployment.
+	It("produces the same request as the nested form of the same parameters", func() {
+		flat := openapiutil.Query(map[string]interface{}{
+			"PrivatePoolOptions.MatchCriteria": "Target",
+			"PrivatePoolOptions.Id":            "eap-bp67acfmxazb4",
+		})
+		nested := openapiutil.Query(map[string]interface{}{
+			"PrivatePoolOptions": map[string]interface{}{
+				"MatchCriteria": "Target",
+				"Id":            "eap-bp67acfmxazb4",
+			},
+		})
+
+		Expect(stringValues(flat)).To(Equal(stringValues(nested)))
+	})
+})

--- a/src/bosh-alicloud-cpi/alicloud/instance_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/instance_manager.go
@@ -109,17 +109,28 @@ func (a InstanceManagerImpl) GetInstance(cid string) (inst *ecs.Instance, err er
 	return
 }
 
+// newCreateInstanceInvoker returns the retry policy CreateInstance runs under.
+//
+// It is a function rather than an inline list so a test can assert against the
+// same policy the call actually uses. What matters to a private pool request is
+// what this does not claim: a Target pool that is out of stock comes back as
+// OperationDenied.NoStock, and retrying that only delays the failure by minutes.
+func newCreateInstanceInvoker() Invoker {
+	invoker := NewInvoker()
+	invoker.AddCatcher(CreateInstanceCatcher_IdempotentProcessing)
+	invoker.AddCatcher(CreateInstanceCatcher_TokenProcessing)
+	invoker.AddCatcher(CreateInstanceCatcher_IpUsed)
+	invoker.AddCatcher(CreateInstanceCatcher_IpUsed2)
+	return invoker
+}
+
 func (a InstanceManagerImpl) CreateInstance(region string, queries map[string]interface{}) (string, error) {
 	conn, err := a.config.EcsTeaClient(region)
 	if err != nil {
 		return "", err
 	}
 
-	invoker := NewInvoker()
-	invoker.AddCatcher(CreateInstanceCatcher_IdempotentProcessing)
-	invoker.AddCatcher(CreateInstanceCatcher_TokenProcessing)
-	invoker.AddCatcher(CreateInstanceCatcher_IpUsed)
-	invoker.AddCatcher(CreateInstanceCatcher_IpUsed2)
+	invoker := newCreateInstanceInvoker()
 
 	action := "CreateInstance"
 	params := &openapi.Params{

--- a/src/bosh-alicloud-cpi/alicloud/invoker_test.go
+++ b/src/bosh-alicloud-cpi/alicloud/invoker_test.go
@@ -109,6 +109,47 @@ var _ = Describe("Invoker", func() {
 		})
 	})
 
+	Describe("the invoker CreateInstance runs under", func() {
+		It("claims the create errors that do clear on their own", func() {
+			invoker := newCreateInstanceInvoker()
+
+			By("a client token still being processed")
+			Expect(invoker.catcherFor(errors.New("LastTokenProcessing"))).NotTo(BeNil())
+			By("an idempotent create still being processed")
+			Expect(invoker.catcherFor(errors.New("IdempotentProcessing"))).NotTo(BeNil())
+			By("an address the previous instance has not released yet")
+			Expect(invoker.catcherFor(errors.New("InvalidPrivateIpAddress.Duplicated"))).NotTo(BeNil())
+			Expect(invoker.catcherFor(errors.New("InvalidIPAddress.AlreadyUsed"))).NotTo(BeNil())
+			By("the service being busy")
+			Expect(invoker.catcherFor(errors.New("ServiceUnavailable"))).NotTo(BeNil())
+		})
+
+		// A private pool request fails for reasons no amount of waiting fixes, and
+		// each must reach the operator as itself. Were any of them claimed here, a
+		// create_vm would sit in the retry loop for minutes and then report "over
+		// max retry" instead of the reason.
+		//
+		// The first four codes are the ones ECS actually returns: they were taken
+		// from CreateInstance with DryRun set, not from the documentation, so a
+		// rename on the ECS side shows up here as a stale test rather than as a
+		// retry loop in production. NoStock is the one case DryRun cannot produce,
+		// since it needs a pool that is genuinely exhausted.
+		It("leaves a private pool rejection to the caller", func() {
+			invoker := newCreateInstanceInvoker()
+
+			By("a pool id that does not exist")
+			Expect(invoker.catcherFor(errors.New("Invalid.PrivatePoolOptions.Id"))).To(BeNil())
+			By("Target asked for with no id")
+			Expect(invoker.catcherFor(errors.New("MissingParameter.PrivatePoolOptionsId"))).To(BeNil())
+			By("an id supplied with a criteria other than Target")
+			Expect(invoker.catcherFor(errors.New("Invalid.PrivatePoolOptionsId"))).To(BeNil())
+			By("a private pool asked for on a spot instance")
+			Expect(invoker.catcherFor(errors.New("SpotNotSupported"))).To(BeNil())
+			By("a Target pool that is out of stock")
+			Expect(invoker.catcherFor(errors.New("OperationDenied.NoStock"))).To(BeNil())
+		})
+	})
+
 	It("gives each invoker its own retry budget", func() {
 		// The catchers are package-level values, so a budget spent by one CPI
 		// call must not leak into the next. Spending it directly keeps this test

--- a/src/bosh-alicloud-cpi/mock/context.go
+++ b/src/bosh-alicloud-cpi/mock/context.go
@@ -35,10 +35,16 @@ type TestContext struct {
 	// call, so tests can assert that update_disk passes the expected timeout/interval.
 	// Stored as a pointer so the mock's copy of TestContext writes through to the original.
 	WaitForDiskSpecOpts *[]time.Duration
+
+	// CreateInstanceArgs records the args passed to the most recent CreateInstance
+	// call, so tests can assert the query keys create_vm builds. Stored as a pointer
+	// so the mock's copy of TestContext writes through to the original.
+	CreateInstanceArgs *map[string]interface{}
 }
 
 func NewTestContext(config alicloud.Config) TestContext {
 	opts := make([]time.Duration, 0)
+	createArgs := make(map[string]interface{})
 	return TestContext{
 		config:              config,
 		Disks:               make(map[string]*ecs.Disk),
@@ -49,6 +55,7 @@ func NewTestContext(config alicloud.Config) TestContext {
 		Snapshots:           make(map[string]string),
 		Flags:               make(map[string]bool),
 		WaitForDiskSpecOpts: &opts,
+		CreateInstanceArgs:  &createArgs,
 	}
 }
 

--- a/src/bosh-alicloud-cpi/mock/instance_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/instance_manager_mock.go
@@ -31,6 +31,8 @@ func (a InstanceManagerMock) GetInstance(cid string) (*ecs.Instance, error) {
 func (a InstanceManagerMock) CreateInstance(region string, args map[string]interface{}) (string, error) {
 	id, inst := a.mc.NewInstance()
 
+	*a.mc.CreateInstanceArgs = args
+
 	if v, ok := args["RegionId"]; ok {
 		inst.RegionId = v.(string)
 	}


### PR DESCRIPTION
## What

Adds support for ECS private pools (`PrivatePoolOptions`) to `create_vm`, so a
deployment can place its VMs into an elasticity assurance (`eap-*`) or a
capacity reservation (`crp-*`) pool:

```yaml
vm_types:
- name: default
  cloud_properties:
    private_pool_options:
      match_criteria: Target   # Open | Target | None
      id: crp-...              # required by Target
```

## How

- `InstanceProps` gains `private_pool_options` (`match_criteria`, `id`),
  validated before any ECS call:
  - `Target` requires an id; `Open`/`None` reject one
  - criteria outside the enum are rejected locally — for those ECS only
    answers `UnknownError`, which says nothing about which field is wrong
  - a private pool on a spot instance is rejected, matching ECS's
    `SpotNotSupported`
- The parameters are sent to ECS as `PrivatePoolOptions.MatchCriteria` /
  `PrivatePoolOptions.Id`. When unset, both keys are left out entirely, so
  existing deployments keep today's behaviour.
- The create retry policy deliberately does not claim private pool rejections
  (`Invalid.PrivatePoolOptions.Id`, `MissingParameter.PrivatePoolOptionsId`,
  `Invalid.PrivatePoolOptionsId`, `SpotNotSupported`,
  `OperationDenied.NoStock`): waiting cannot fix any of them, and the reason
  must reach the operator instead of "over max retry". To let a test assert
  against the same policy the call actually runs under, the four
  create-specific catchers are assembled in `newCreateInstanceInvoker()`
  instead of inline; behaviour is unchanged.

## Verification

- **Unit tests**: action suite 88 specs, alicloud suite 64 specs, all passing.
  New coverage includes the query mapping (Target/eap, Target/crp, explicit
  None, id trimming), the validation rules, the parameter names surviving
  `openapiutil.Query` flattening (flat form equals nested form), and the
  create retry policy. Two mutation checks confirm the assertions turn red
  when the code under test is broken.
- **Concourse**: the branch ran through the full pipeline — build-candidate,
  integration, bats and end-2-end all green.
- **Real ECS, zero resources created**: `CreateInstance` with `DryRun=true`
  confirms ECS parses the dot-form parameter names rather than ignoring them —
  `Target` without an id returns `MissingParameter.PrivatePoolOptionsId`, a
  bogus pool id returns `Invalid.PrivatePoolOptions.Id`, an id under `None`
  returns `Invalid.PrivatePoolOptionsId`, and spot + pool returns
  `SpotNotSupported`.
